### PR TITLE
Set up Cursor Cloud dev environment + document caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,17 @@ Docs:
 - Codex-Monitor (Tauri, feature-complete, strong reference implementation): https://github.com/Dimillian/CodexMonitor
 
 Use these as implementation references when designing protocol handling, UX flows, and operational safeguards.
+
+## Cursor Cloud specific instructions
+
+Toolchain is managed by `mise` (Node + Bun pinned in `.mise.toml`) and is already on `PATH` for new shells (activated in `~/.bashrc`). The startup update script runs `bun install`. Standard tasks are unchanged: see root `package.json` scripts (`bun run dev`, `bun run lint`, `bun run typecheck`, `bun run test`, `bun run build`). Per the rules above, run `bun run test` (never `bun test`).
+
+Non-obvious caveats discovered in this environment:
+
+- Running the dev stack headless: the `t3` server CLI puts the controlling terminal into raw mode on startup. If it is launched in a background process group that still has a controlling TTY (e.g. directly in a tmux pane, or piped through `tee`), it receives `SIGTTOU` and is left in the `T` (stopped) state *before* it binds its HTTP/WebSocket port — so the server logs stop right after "orchestration engine started", the port never opens, and the UI never connects. Launch it detached from any controlling terminal. Working pattern (inside a tmux pane, so the process survives the shell):
+  `setsid bash -c "TURBO_UI=stream env -u T3CODE_AUTH_TOKEN T3CODE_NO_BROWSER=1 bun run dev -- --home-dir ./.synara-dev > /tmp/synara-dev.log 2>&1 < /dev/null"`
+  `TURBO_UI=stream` avoids turbo's interactive TUI; redirecting stdin from `/dev/null` and logging to a file keeps it non-interactive.
+- Default dev ports: server `3773`, web (Vite) `5733`. The Vite dev server binds IPv6 `localhost` only (`[::1]:5733`) — open `http://localhost:5733` or `http://[::1]:5733`; `http://127.0.0.1:5733` will NOT connect. The backend binds all interfaces on `3773`.
+- First cold load of the Vite dev server is heavy (very large module graph); the browser can show `ERR_INSUFFICIENT_RESOURCES` or a long blank/loading screen on the very first hit. Just wait and/or reload the same URL — once Vite has transformed/cached modules, subsequent loads are fast.
+- Provider agent CLIs (`codex`, `claude`, `gemini`, `cursor`, `grok`, `kilo`, `opencode`, `pi`) are NOT installed and require the user's own subscriptions/auth, so live agent chat turns cannot run here. Everything else works without a provider: the app boots, auto-bootstraps a project from the cwd, and the integrated terminal (`Ctrl/Cmd+J`), thread creation, etc. are all functional.
+- One `apps/server` test fails only in this environment: `GitCore > reuses an existing remote when the target URL only differs by a trailing slash after .git`. The cloud VM's `~/.gitconfig` has GitHub-auth `url.<token>.insteadOf` rewrites that rewrite the test's `git@github.com:` URL, so `git remote -v` returns a different URL and the dedup check sees a mismatch. It passes with a neutral global config (e.g. `GIT_CONFIG_GLOBAL=/dev/null`); it is not a code issue.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Synara development environment for Cursor Cloud agents and records the non-obvious caveats discovered during setup in `AGENTS.md`.

The only code/repo change is documentation: a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. The toolchain (mise → Node 24.13.1 + Bun 1.3.9) and the startup update script (`bun install`) are configured at the environment level, not in the repo.

## Environment

- Toolchain via `mise` (pins from `.mise.toml`): Node `24.13.1`, Bun `1.3.9`. Activated on `PATH` for new shells.
- Update script (runs on VM startup): `mise install` + `bun install` (with a PATH guard so it's reliable regardless of shell init).

## Verification

All standard checks pass; the app runs in dev mode and a provider-independent hello-world (integrated terminal) was exercised end-to-end.

| Check | Command | Result |
|---|---|---|
| Native deps | `node scripts/node-pty-smoke.mjs` | ✅ pass |
| Lint | `bun run lint` | ✅ pass (155 warnings, 0 errors) |
| Typecheck | `bun run typecheck` | ✅ pass (8/8) |
| Tests | `bun run test` | ✅ 1474 passed, 6 skipped, 1 env-only failure* |
| Build | `bun run build` | ✅ pass (6/6) |
| Run (dev) | `bun run dev` → server `:3773`, web `:5733` | ✅ UI loads, integrated terminal works |

*The single failing test (`GitCore > reuses an existing remote when the target URL only differs by a trailing slash after .git`) fails ONLY because the cloud VM's `~/.gitconfig` has GitHub-auth `url.insteadOf` rewrites; it passes with a neutral global git config. Not a code issue.

### Hello-world demo (integrated terminal)

Ran `echo "Hello from Synara" && pwd && git rev-parse --abbrev-ref HEAD` in Synara's integrated terminal (opened via `Ctrl/Cmd+J`), output: `Hello from Synara`, `/workspace`, `main`.

[synara_terminal_hello_world.mp4](https://cursor.com/agents/bc-f24bb39b-86b0-48b9-9d00-5c0d2df9d3ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsynara_terminal_hello_world.mp4)

[Synara integrated terminal output](https://cursor.com/agents/bc-f24bb39b-86b0-48b9-9d00-5c0d2df9d3ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsynara_terminal_output.webp)

## Notable caveat for headless runs

The `t3` server CLI puts the controlling terminal into raw mode at startup; if launched in a background process group that still has a controlling TTY, it gets `SIGTTOU`-stopped before binding its port. Launch the dev stack detached, e.g. inside tmux: `setsid bash -c "TURBO_UI=stream ... bun run dev ... > log 2>&1 < /dev/null"`. Full details in `AGENTS.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f24bb39b-86b0-48b9-9d00-5c0d2df9d3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f24bb39b-86b0-48b9-9d00-5c0d2df9d3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cursor Cloud setup docs in AGENTS.md covering the `mise` toolchain (Node 24.13.1, `bun` 1.3.9), startup install steps, default ports, headless-run guidance, and an environment-specific test note. No code changes; this clarifies non-obvious caveats for cloud agents.

<sup>Written for commit 8ac01bcd6a37e55dede5ec2a5ebfaf761aef4867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/synara/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

