### PR TITLE
KAR-521: Rebase and finish generic ACP foundation (#533)

### DIFF
--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -40,7 +40,6 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -72,6 +71,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   makeAcpThreadLock,
   readAcpUsdCost,
@@ -741,16 +741,10 @@ export function makeCursorAdapter(
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientInfo: { name: "Synara", version: "0.0.0" },
             startupTimeouts: CURSOR_ACP_STARTUP_TIMEOUTS,
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpNativeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -39,7 +39,6 @@ import {
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -74,6 +73,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
@@ -864,16 +864,10 @@ export function makeDroidAdapter(
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientCapabilities: { elicitation: { form: {} } },
             clientInfo: { name: "Synara", version: "0.0.0" },
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult: Acp.InitializeResponse) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpRuntimeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -42,7 +42,6 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -75,6 +74,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
@@ -1111,16 +1111,10 @@ export function makeGrokAdapter(
             // initialize.clientCapabilities. Re-send this on load/resume so a
             // reconnected session keeps the Plan-mode write gate.
             sessionMeta: GROK_SESSION_META,
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpRuntimeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/acp/AcpAdapterSessionSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSessionSupport.test.ts
@@ -1,7 +1,10 @@
 import { ThreadId, TurnId, type ProviderSession } from "@synara/contracts";
+
+import { SYNARA_AGENT_GATEWAY_TOKEN_ENV } from "../../agentGateway/mcpInjection.ts";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAcpGatewayMcpServers,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
   recordAcpSessionCost,
@@ -211,5 +214,60 @@ describe("ACP adapter session support", () => {
         homeDir: "/home/test",
       }),
     ).toBe("/server");
+  });
+});
+
+describe("buildAcpGatewayMcpServers", () => {
+  const connection = {
+    url: "http://127.0.0.1:3773/mcp",
+    bearerToken: "sagw_abc.def",
+  };
+  const stdioProxy = {
+    command: "/usr/local/bin/node",
+    args: ["/state/agent-gateway-mcp-proxy.mjs"],
+  };
+
+  it("builds an HTTP gateway server when the agent advertises http support", () => {
+    const options = buildAcpGatewayMcpServers({
+      gatewaySessionLease: { connection },
+      agentGatewayCredentials: { stdioProxy },
+    });
+    expect(
+      options.buildMcpServers?.({ agentCapabilities: { mcpCapabilities: { http: true } } }),
+    ).toEqual([
+      {
+        type: "http",
+        name: "synara",
+        url: connection.url,
+        headers: [{ name: "Authorization", value: `Bearer ${connection.bearerToken}` }],
+      },
+    ]);
+  });
+
+  it("falls back to the stdio proxy when http is not advertised", () => {
+    const options = buildAcpGatewayMcpServers({
+      gatewaySessionLease: { connection },
+      agentGatewayCredentials: { stdioProxy },
+    });
+    expect(options.buildMcpServers?.({})).toEqual([
+      {
+        name: "synara",
+        command: stdioProxy.command,
+        args: stdioProxy.args,
+        env: [
+          { name: "SYNARA_AGENT_GATEWAY_URL", value: connection.url },
+          { name: SYNARA_AGENT_GATEWAY_TOKEN_ENV, value: connection.bearerToken },
+        ],
+      },
+    ]);
+  });
+
+  it("skips gateway injection when the gateway is not running", () => {
+    expect(
+      buildAcpGatewayMcpServers({
+        gatewaySessionLease: undefined,
+        agentGatewayCredentials: undefined,
+      }),
+    ).toEqual({});
   });
 });

--- a/apps/server/src/provider/acp/AcpAdapterSessionSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSessionSupport.ts
@@ -16,6 +16,14 @@ import type {
 import { Deferred, Effect, Option, Semaphore, SynchronizedRef } from "effect";
 import type * as Acp from "@agentclientprotocol/sdk";
 
+import {
+  buildAcpSynaraMcpServers,
+  type AcpInitializeCapabilitiesView,
+} from "../../agentGateway/mcpInjection.ts";
+import type {
+  AgentGatewayMcpConnection,
+  AgentGatewayStdioProxySpawn,
+} from "../../agentGateway/Services/AgentGatewayCredentials.ts";
 import type { AcpSessionMode, AcpSessionModeState, AcpToolCallState } from "./AcpRuntimeModel.ts";
 
 export interface AcpSessionModeAliases {
@@ -272,4 +280,36 @@ export function acceptAcpPlanUpdate(
   if (context.lastPlanFingerprint === fingerprint) return false;
   context.lastPlanFingerprint = fingerprint;
   return true;
+}
+
+/**
+ * Builds the `buildMcpServers` runtime option from a live agent gateway lease.
+ *
+ * Shared by every ACP adapter so gateway injection rules cannot drift between
+ * first-party agents and future generic ACP agents. The result is spread into
+ * `AcpSessionRuntimeOptions`; it is empty when the gateway is not running, so
+ * ACP sessions then start without gateway injection. The builder negotiates
+ * the transport from the agent's advertised `mcpCapabilities`: streamable HTTP
+ * when supported, otherwise the stdio -> HTTP proxy that keeps the bearer
+ * token out of provider processes.
+ */
+export function buildAcpGatewayMcpServers(input: {
+  readonly gatewaySessionLease: { readonly connection: AgentGatewayMcpConnection } | undefined;
+  readonly agentGatewayCredentials:
+    | { readonly stdioProxy: AgentGatewayStdioProxySpawn }
+    | undefined;
+}): {
+  readonly buildMcpServers?: (
+    initializeResult: AcpInitializeCapabilitiesView,
+  ) => Array<Acp.McpServer>;
+} {
+  if (input.gatewaySessionLease === undefined || input.agentGatewayCredentials === undefined) {
+    return {};
+  }
+  const { connection } = input.gatewaySessionLease;
+  const { stdioProxy } = input.agentGatewayCredentials;
+  return {
+    buildMcpServers: (initializeResult) =>
+      buildAcpSynaraMcpServers({ connection, initializeResult, stdioProxy }),
+  };
 }

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -1,9 +1,16 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it as effectIt } from "@effect/vitest";
 import { describe, expect, it } from "vitest";
 
 import { Deferred, Effect, Exit, Scope } from "effect";
 import type * as Acp from "@agentclientprotocol/sdk";
 
 import {
+  AcpSessionRuntime,
+  type AcpSessionRequestLogEvent,
   assistantItemId,
   awaitAcpChildExit,
   decodeSetSessionConfigOptionResponse,
@@ -230,5 +237,73 @@ describe("sessionConfigOptionsFromSetup", () => {
 
   it("uses an explicit setup inventory instead of replayed config", () => {
     expect(sessionConfigOptionsFromSetup({ configOptions: [] }, replayedConfigOptions)).toEqual([]);
+  });
+});
+
+describe("startup authentication negotiation", () => {
+  const bunExe = process.execPath;
+  const mockAgentPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/acp-mock-agent.ts",
+  );
+  const conformanceAgentPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/acp-conformance-agent.ts",
+  );
+
+  effectIt.effect("starts a no-auth agent and skips authenticate", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const started = yield* runtime.start();
+
+      expect(started.sessionId).toBe("mock-session-1");
+      expect(started.sessionSetupMethod).toBe("new");
+      expect(requestEvents.filter((event) => event.method === "authenticate")).toEqual([]);
+      expect(
+        requestEvents.some((event) => event.method === "session/new" && event.status === "started"),
+      ).toBe(true);
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [mockAgentPath],
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+          requestLogger: (event) =>
+            Effect.sync(() => {
+              requestEvents.push(event);
+            }),
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
+  });
+
+  effectIt.effect("keeps failing when an agent advertises methods but none resolve", () => {
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const failure = yield* runtime.start().pipe(Effect.flip);
+      expect(failure._tag).toBe("AcpRequestError");
+      if (failure._tag === "AcpRequestError") {
+        expect(failure.errorMessage).toBe("ACP agent did not provide an authentication method.");
+      }
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [conformanceAgentPath],
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -1081,33 +1081,39 @@ const makeAcpSessionRuntime = (
         startupTimeouts.initializeMs,
         runLoggedRequest("initialize", initializePayload, acp.agent.initialize(initializePayload)),
       );
+      const advertisedAuthMethods = initializeResult.authMethods ?? [];
       const authMethodId =
         options.resolveAuthMethodId !== undefined
           ? yield* options.resolveAuthMethodId(initializeResult)
           : options.authMethodId;
 
-      if (!authMethodId) {
-        return yield* new AcpErrors.AcpRequestError({
-          code: -32602,
-          errorMessage: "ACP agent did not provide an authentication method.",
-          data: { authMethods: initializeResult.authMethods ?? [] },
-        });
-      }
+      // Agents that advertise no auth methods require no authenticate step;
+      // requiring one here would make any no-auth agent unstartable. The error
+      // is only for agents that advertise methods but none resolve.
+      if (advertisedAuthMethods.length > 0) {
+        if (!authMethodId) {
+          return yield* new AcpErrors.AcpRequestError({
+            code: -32602,
+            errorMessage: "ACP agent did not provide an authentication method.",
+            data: { authMethods: advertisedAuthMethods },
+          });
+        }
 
-      const authenticatePayload = {
-        methodId: authMethodId,
-        ...(options.authenticateMeta ? { _meta: options.authenticateMeta } : {}),
-      } satisfies Acp.AuthenticateRequest;
+        const authenticatePayload = {
+          methodId: authMethodId,
+          ...(options.authenticateMeta ? { _meta: options.authenticateMeta } : {}),
+        } satisfies Acp.AuthenticateRequest;
 
-      yield* withStartupTimeout(
-        "authenticate",
-        startupTimeouts.authenticateMs,
-        runLoggedRequest(
+        yield* withStartupTimeout(
           "authenticate",
-          authenticatePayload,
-          acp.agent.authenticate(authenticatePayload),
-        ),
-      );
+          startupTimeouts.authenticateMs,
+          runLoggedRequest(
+            "authenticate",
+            authenticatePayload,
+            acp.agent.authenticate(authenticatePayload),
+          ),
+        );
+      }
 
       const mcpServers = options.buildMcpServers?.(initializeResult) ?? [];
 


### PR DESCRIPTION
## Linked issues

- **KAR-521 — Rebase and finish generic ACP foundation** → #140
- **Map:** #138 · **PRD:** #139

---

Part of **Synara — Bring Your Own Agents** (BYO Agents v1) — [PRD](https://linear.app/kartiksworkspace/document/prd-bring-your-own-agents-1b6330f9c430).

## What this is
Implements [KAR-521](https://linear.app/kartiksworkspace/issue/KAR-521) — the stable generic ACP foundation on top of PR #533.

Recovered from Ascii Box `bx_5pj9ujfh` (grok session `019fdf2a`) — the only surviving copy of this work. Single commit `d721778c5`.

## Changes (7 files, +213/−52)
- `AcpSessionRuntime.ts` — **no-auth ACP start**: agents that advertise zero auth methods skip the `authenticate` step (previously every agent was unstartable without one). Auth is still required when the agent advertises methods but none resolve.
- New `AcpAdapterSessionSupport.ts` — shared, provider-independent ACP session bookkeeping (gateway/MCP injection via `buildAcpSynaraMcpServers`, turn-local scoping, mode aliasing).
- `CursorAdapter` / `DroidAdapter` / `GrokAdapter` — refactored onto the shared session support.
- Tests: `AcpAdapterSessionSupport.test.ts` (+58), `AcpSessionRuntime.test.ts` (+75).

## Acceptance mapping
- ✓ Generic ACP sessions receive the same shared gateway/tool injection as first-party paths
- ✓ No agent-name branches in the generic runtime
- ✓ No-auth ACP agent starts correctly
- ✓ First-party ACP providers untouched in behavior

## Status / caveats
- Base is `02c8a6cb9` (Aug 9 upstream main) — this is an ancestor of current main, so the diff is clean, but a fast-forward rebase onto latest main is recommended before merge (no conflicts expected).
- Not yet run through `bun fmt:check` / `bun lint` / `bun typecheck` on current main; the original run died mid-verification (model context overflow).
- Draft: BYO v1 is 2 of 14 issues. Mark ready when the wave-1 gates are run.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements KAR-521 generic ACP foundation by unifying gateway→MCP injection and allowing no‑auth agents to start. Previously all ACP agents required an auth method; now agents that advertise zero methods skip authenticate, while agents that advertise methods but resolve none still error.

- Review notes
  - Centralizes gateway MCP injection via `buildAcpGatewayMcpServers` in `AcpAdapterSessionSupport`: uses HTTP when the agent advertises `mcpCapabilities.http`, otherwise falls back to a stdio→HTTP proxy with the bearer token in env; skips injection when the gateway is absent.
  - Refactors `CursorAdapter`, `DroidAdapter`, and `GrokAdapter` to use the shared session support; first‑party provider behavior remains unchanged.
  - Adds tests for gateway transport selection and startup authentication negotiation.

<sup>Written for commit 5d1f102a1b86a1a126ec29f3478208c889e5fb68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/synara/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Closes #140