### PR TITLE
KAR-523: Build canonical capability evidence model

### DIFF
--- a/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceRepository.ts
+++ b/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceRepository.ts
@@ -1,0 +1,230 @@
+import type {
+  CapabilityObservation,
+  EffectiveCapabilityStateView,
+  PolicySpec,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+} from "@synara/contracts";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import {
+  CapabilityEvidenceRepository,
+  type CapabilityEvidenceRepositoryShape,
+} from "../Services/CapabilityEvidenceRepository.ts";
+
+const repositoryError = (operation: string) => (cause: unknown) =>
+  new Error(`Capability evidence repository failed during ${operation}.`, { cause });
+
+interface ObservationRow {
+  readonly observationId: string;
+  readonly namespace: string;
+  readonly capabilityId: string;
+  readonly source: string;
+  readonly outcome: string;
+  readonly attribution: string;
+  readonly runtimeIdentityJson: string | null;
+  readonly verifierJson: string | null;
+  readonly policyJson: string | null;
+  readonly observedAt: string;
+  readonly runMetadataJson: string | null;
+}
+
+interface EffectiveStateRow {
+  readonly namespace: string;
+  readonly capabilityId: string;
+  readonly state: string;
+  readonly advertised: number;
+  readonly policyJson: string | null;
+  readonly lastObservationAt: string | null;
+  readonly lastObservationId: string | null;
+  readonly derivedAt: string;
+}
+
+const parseJson = <T>(value: string | null, fallback: T): T => {
+  if (value === null || value === undefined) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+const toObservation = (row: ObservationRow): CapabilityObservation => ({
+  observationId: row.observationId,
+  namespace: row.namespace,
+  capabilityId: row.capabilityId as CapabilityObservation["capabilityId"],
+  source: row.source as CapabilityObservation["source"],
+  outcome: row.outcome as CapabilityObservation["outcome"],
+  attribution: row.attribution as CapabilityObservation["attribution"],
+  runtime: parseJson<RuntimeIdentitySignals>(row.runtimeIdentityJson, {}),
+  verifier: parseJson<VerifierIdentity>(row.verifierJson, { verifierId: "unknown" }),
+  policy: parseJson<PolicySpec>(row.policyJson, { version: "unknown", params: {} }),
+  observedAt: row.observedAt,
+  run: row.runMetadataJson === null ? undefined : parseJson(row.runMetadataJson, undefined),
+});
+
+const toEffectiveState = (row: EffectiveStateRow): EffectiveCapabilityStateView => ({
+  namespace: row.namespace,
+  capabilityId: row.capabilityId as EffectiveCapabilityStateView["capabilityId"],
+  state: row.state as EffectiveCapabilityStateView["state"],
+  advertised: row.advertised === 1,
+  policy: parseJson<PolicySpec>(row.policyJson, { version: "unknown", params: {} }),
+  lastObservationAt: row.lastObservationAt ?? undefined,
+  lastObservationId: row.lastObservationId ?? undefined,
+  derivedAt: row.derivedAt,
+});
+
+export const makeCapabilityEvidenceRepository = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const appendObservation: CapabilityEvidenceRepositoryShape["appendObservation"] = (input) =>
+    sql`
+      INSERT INTO capability_observations (
+        observation_id, namespace, capability_id, source, outcome, attribution,
+        runtime_identity_json, verifier_json, policy_json, observed_at, run_metadata_json
+      ) VALUES (
+        ${input.observation.observationId}, ${input.observation.namespace},
+        ${input.observation.capabilityId}, ${input.observation.source},
+        ${input.observation.outcome}, ${input.observation.attribution},
+        ${JSON.stringify(input.observation.runtime)},
+        ${JSON.stringify(input.observation.verifier)},
+        ${JSON.stringify(input.observation.policy)},
+        ${input.observation.observedAt},
+        ${input.observation.run === undefined ? null : JSON.stringify(input.observation.run)}
+      )
+    `.pipe(Effect.asVoid, Effect.mapError(repositoryError("appendObservation")));
+
+  const listObservations: CapabilityEvidenceRepositoryShape["listObservations"] = (input) =>
+    (input.capabilityId === undefined
+      ? sql<ObservationRow>`
+          SELECT
+            observation_id AS "observationId", namespace, capability_id AS "capabilityId",
+            source, outcome, attribution,
+            runtime_identity_json AS "runtimeIdentityJson",
+            verifier_json AS "verifierJson", policy_json AS "policyJson",
+            observed_at AS "observedAt", run_metadata_json AS "runMetadataJson"
+          FROM capability_observations
+          WHERE namespace = ${input.namespace}
+          ORDER BY observed_at DESC, observation_id DESC
+        `
+      : sql<ObservationRow>`
+          SELECT
+            observation_id AS "observationId", namespace, capability_id AS "capabilityId",
+            source, outcome, attribution,
+            runtime_identity_json AS "runtimeIdentityJson",
+            verifier_json AS "verifierJson", policy_json AS "policyJson",
+            observed_at AS "observedAt", run_metadata_json AS "runMetadataJson"
+          FROM capability_observations
+          WHERE namespace = ${input.namespace} AND capability_id = ${input.capabilityId}
+          ORDER BY observed_at DESC, observation_id DESC
+        `
+    ).pipe(
+      Effect.map((rows) => rows.map(toObservation)),
+      Effect.mapError(repositoryError("listObservations")),
+    );
+
+  const latestRuntimeIdentity: CapabilityEvidenceRepositoryShape["latestRuntimeIdentity"] = (
+    namespace,
+  ) =>
+    sql<{ readonly runtimeIdentityJson: string | null }>`
+      SELECT runtime_identity_json AS "runtimeIdentityJson"
+      FROM capability_observations
+      WHERE namespace = ${namespace}
+      ORDER BY observed_at DESC, observation_id DESC
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) =>
+        rows[0]
+          ? parseJson<RuntimeIdentitySignals | null>(rows[0].runtimeIdentityJson, null)
+          : null,
+      ),
+      Effect.mapError(repositoryError("latestRuntimeIdentity")),
+    );
+
+  const latestVerifierIdentity: CapabilityEvidenceRepositoryShape["latestVerifierIdentity"] = (
+    namespace,
+  ) =>
+    sql<{ readonly verifierJson: string | null }>`
+      SELECT verifier_json AS "verifierJson"
+      FROM capability_observations
+      WHERE namespace = ${namespace}
+      ORDER BY observed_at DESC, observation_id DESC
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) =>
+        rows[0] ? parseJson<VerifierIdentity | null>(rows[0].verifierJson, null) : null,
+      ),
+      Effect.mapError(repositoryError("latestVerifierIdentity")),
+    );
+
+  const latestPolicySpec: CapabilityEvidenceRepositoryShape["latestPolicySpec"] = (namespace) =>
+    sql<{ readonly policyJson: string | null }>`
+      SELECT policy_json AS "policyJson"
+      FROM capability_observations
+      WHERE namespace = ${namespace}
+      ORDER BY observed_at DESC, observation_id DESC
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) =>
+        rows[0] ? parseJson<PolicySpec | null>(rows[0].policyJson, null) : null,
+      ),
+      Effect.mapError(repositoryError("latestPolicySpec")),
+    );
+
+  const upsertEffectiveState: CapabilityEvidenceRepositoryShape["upsertEffectiveState"] = (input) =>
+    sql`
+      INSERT INTO capability_effective_states (
+        namespace, capability_id, state, advertised, policy_json,
+        last_observation_at, last_observation_id, derived_at
+      ) VALUES (
+        ${input.state.namespace}, ${input.state.capabilityId}, ${input.state.state},
+        ${input.state.advertised ? 1 : 0}, ${JSON.stringify(input.state.policy)},
+        ${input.state.lastObservationAt ?? null}, ${input.state.lastObservationId ?? null},
+        ${input.state.derivedAt}
+      )
+      ON CONFLICT (namespace, capability_id) DO UPDATE SET
+        state = excluded.state,
+        advertised = excluded.advertised,
+        policy_json = excluded.policy_json,
+        last_observation_at = excluded.last_observation_at,
+        last_observation_id = excluded.last_observation_id,
+        derived_at = excluded.derived_at
+    `.pipe(Effect.asVoid, Effect.mapError(repositoryError("upsertEffectiveState")));
+
+  const getEffectiveState: CapabilityEvidenceRepositoryShape["getEffectiveState"] = (input) =>
+    sql<EffectiveStateRow>`
+      SELECT
+        namespace, capability_id AS "capabilityId", state, advertised, policy_json AS "policyJson",
+        last_observation_at AS "lastObservationAt", last_observation_id AS "lastObservationId",
+        derived_at AS "derivedAt"
+      FROM capability_effective_states
+      WHERE namespace = ${input.namespace} AND capability_id = ${input.capabilityId}
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) => (rows[0] ? toEffectiveState(rows[0]) : null)),
+      Effect.mapError(repositoryError("getEffectiveState")),
+    );
+
+  const clearEffectiveStates: CapabilityEvidenceRepositoryShape["clearEffectiveStates"] = (input) =>
+    sql`
+      DELETE FROM capability_effective_states
+      WHERE namespace = ${input.namespace}
+    `.pipe(Effect.asVoid, Effect.mapError(repositoryError("clearEffectiveStates")));
+
+  return {
+    appendObservation,
+    listObservations,
+    latestRuntimeIdentity,
+    latestVerifierIdentity,
+    latestPolicySpec,
+    upsertEffectiveState,
+    getEffectiveState,
+    clearEffectiveStates,
+  } satisfies CapabilityEvidenceRepositoryShape;
+});
+
+export const CapabilityEvidenceRepositoryLive = Layer.effect(
+  CapabilityEvidenceRepository,
+  makeCapabilityEvidenceRepository,
+);

--- a/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceService.ts
+++ b/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceService.ts
@@ -1,0 +1,32 @@
+import { Layer } from "effect";
+
+import { CapabilityEvidenceRepositoryLive } from "./CapabilityEvidenceRepository.ts";
+import {
+  CapabilityEvidenceService,
+  makeCapabilityEvidenceService,
+} from "../Services/CapabilityEvidenceService.ts";
+import {
+  CapabilityPolicyEngine,
+  makeCapabilityPolicyEngine,
+} from "../Services/CapabilityPolicyEngine.ts";
+
+export const CapabilityPolicyEngineLive = Layer.effect(
+  CapabilityPolicyEngine,
+  makeCapabilityPolicyEngine,
+);
+
+export const CapabilityEvidenceServiceLayer = Layer.effect(
+  CapabilityEvidenceService,
+  makeCapabilityEvidenceService,
+);
+
+/**
+ * The capability/evidence service graph: repository (append-only persistence),
+ * policy engine (pure verdict derivation), and the service that glues them.
+ * The service layer is `provideMerge`d over its two dependency layers so the
+ * result has no service requirement beyond SQLite.
+ */
+export const capabilityEvidenceLayer = CapabilityEvidenceServiceLayer.pipe(
+  Layer.provideMerge(CapabilityEvidenceRepositoryLive),
+  Layer.provideMerge(CapabilityPolicyEngineLive),
+);

--- a/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceRepository.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceRepository.ts
@@ -1,0 +1,72 @@
+import type {
+  CapabilityId,
+  CapabilityObservation,
+  EffectiveCapabilityStateView,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+  PolicySpec,
+} from "@synara/contracts";
+import { ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+export interface CapabilityObservationRecord extends CapabilityObservation {}
+
+export interface CapabilityEvidenceRepositoryShape {
+  /**
+   * Append one immutable observation. Never updates or deletes prior rows.
+   */
+  readonly appendObservation: (input: {
+    readonly observation: CapabilityObservation;
+  }) => Effect.Effect<void, Error>;
+  /**
+   * List observations for a profile (and optionally a single capability),
+   * newest first.
+   */
+  readonly listObservations: (input: {
+    readonly namespace: string;
+    readonly capabilityId?: CapabilityId;
+  }) => Effect.Effect<ReadonlyArray<CapabilityObservation>, Error>;
+  /**
+   * Latest observed runtime identity signals for a profile. Used to detect
+   * drift when a new observation arrives with different signals.
+   */
+  readonly latestRuntimeIdentity: (
+    namespace: string,
+  ) => Effect.Effect<RuntimeIdentitySignals | null, Error>;
+  /**
+   * Latest verifier identity + harness version seen for a profile.
+   */
+  readonly latestVerifierIdentity: (
+    namespace: string,
+  ) => Effect.Effect<VerifierIdentity | null, Error>;
+  /**
+   * Latest policy spec seen for a profile.
+   */
+  readonly latestPolicySpec: (namespace: string) => Effect.Effect<PolicySpec | null, Error>;
+  /**
+   * Persist a single effective-state snapshot keyed by (namespace, capability).
+   * Stored as a derived cache, never as source of truth — re-derivation recomputes it.
+   */
+  readonly upsertEffectiveState: (input: {
+    readonly state: EffectiveCapabilityStateView;
+  }) => Effect.Effect<void, Error>;
+  /**
+   * Read the persisted effective state for a capability, if any.
+   */
+  readonly getEffectiveState: (input: {
+    readonly namespace: string;
+    readonly capabilityId: CapabilityId;
+  }) => Effect.Effect<EffectiveCapabilityStateView | null, Error>;
+  /**
+   * Delete effective-state cache rows for a profile (used by invalidation).
+   * Does not touch observation rows.
+   */
+  readonly clearEffectiveStates: (input: {
+    readonly namespace: string;
+  }) => Effect.Effect<void, Error>;
+}
+
+export class CapabilityEvidenceRepository extends ServiceMap.Service<
+  CapabilityEvidenceRepository,
+  CapabilityEvidenceRepositoryShape
+>()("synara/capabilityEvidence/Services/CapabilityEvidenceRepository") {}

--- a/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.test.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.test.ts
@@ -1,0 +1,199 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { describe } from "vitest";
+
+import type { PolicySpec, RuntimeIdentitySignals, VerifierIdentity } from "@synara/contracts";
+
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import { capabilityEvidenceLayer } from "../Layers/CapabilityEvidenceService.ts";
+import { CAPABILITY_EVIDENCE_POLICY_VERSION } from "./CapabilityPolicyEngine.ts";
+import { CapabilityEvidenceService } from "./CapabilityEvidenceService.ts";
+
+const testLayer = capabilityEvidenceLayer.pipe(Layer.provideMerge(SqlitePersistenceMemory));
+
+const layer = it.layer(testLayer);
+
+let profileSeq = 0;
+const namespace = () => `synara:claudeAgent:profile-${++profileSeq}`;
+const identity: RuntimeIdentitySignals = {
+  agentName: "claude-agent",
+  agentVersion: "1.2.3",
+  protocolVersion: "2025-06-26",
+  advertisedContractHash: "abc123",
+};
+const verifier: VerifierIdentity = {
+  verifierId: "conformance-v1",
+  harnessVersion: "2026-08-03.8",
+};
+const policy: PolicySpec = { version: CAPABILITY_EVIDENCE_POLICY_VERSION, params: {} };
+
+let seq = 0;
+const observedAt = () => new Date(Date.UTC(2026, 7, 16, 0, 0, ++seq)).toISOString();
+
+describe("CapabilityEvidenceService", () => {
+  layer("append-only record + query (AC #1, #2, #5)", (it) => {
+    it.effect("records observations and queries them back with a derived state", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+
+        const recorded = yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "synthetic-conformance",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        assert.strictEqual(recorded.observation.outcome, "pass");
+
+        const result = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(result.observations.length, 1);
+        assert.strictEqual(result.state?.capabilityId, "prompt");
+        assert.strictEqual(result.state?.state, "verified");
+      }),
+    );
+
+    it.effect("advertised + verified fail → disabled (AC #2 persists the combination)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "session.start",
+          source: "protocol-claim",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "session.start",
+          source: "synthetic-conformance",
+          outcome: "fail",
+          attribution: "agent",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+
+        const result = yield* service.query({ namespace: ns, capabilityId: "session.start" });
+        const broken = result.observations.find((ob) => ob.capabilityId === "session.start");
+        assert.ok(broken);
+        assert.strictEqual(broken.outcome, "fail");
+        // `advertised: true` (from the protocol claim) + `state: "broken"`
+        // (first verification failed) is the canonical disabled combination.
+        assert.strictEqual(result.state?.advertised, true);
+        assert.strictEqual(result.state?.state, "broken");
+      }),
+    );
+
+    it.effect("env/auth/network failures read inconclusive (AC #3)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "stream",
+          source: "production-observation",
+          outcome: "fail",
+          attribution: "network",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const result = yield* service.query({ namespace: ns, capabilityId: "stream" });
+        assert.strictEqual(result.observations[0]?.attribution, "network");
+        assert.strictEqual(result.state?.state, "provisional");
+      }),
+    );
+
+    it.effect("new capability reads unknown for profiles with no history (AC #4)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "production-observation",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const result = yield* service.query({ namespace: ns, capabilityId: "model.switch" });
+        assert.strictEqual(result.observations.length, 0);
+        assert.strictEqual(result.state?.state, "unknown");
+      }),
+    );
+
+    it.effect("never overwrites earlier observations (append-only)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        const first = yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "vendor-attestation",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const second = yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "synthetic-conformance",
+          outcome: "fail",
+          attribution: "agent",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        assert.notEqual(first.observation.observationId, second.observation.observationId);
+
+        const result = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(result.observations.length, 2);
+      }),
+    );
+
+    it.effect("invalidate clears derived state without touching observations (AC #5)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "synthetic-conformance",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const before = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(before.state?.state, "verified");
+
+        const invalidation = yield* service.invalidate({ namespace: ns });
+        assert.strictEqual(invalidation.invalidated, 1);
+
+        const after = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(after.state?.state, "verified"); // re-derived from history
+      }),
+    );
+  });
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.ts
@@ -1,0 +1,137 @@
+import type {
+  CapabilityAdvertisement,
+  CapabilityEvidenceInvalidateInput,
+  CapabilityEvidenceInvalidateResult,
+  CapabilityEvidenceQuery,
+  CapabilityEvidenceQueryResult,
+  CapabilityEvidenceRecordInput,
+  CapabilityEvidenceRecordResult,
+  CapabilityObservation,
+} from "@synara/contracts";
+import { Data, Effect, Random, ServiceMap } from "effect";
+
+import { CapabilityEvidenceRepository } from "./CapabilityEvidenceRepository.ts";
+import {
+  CAPABILITY_EVIDENCE_POLICY_VERSION,
+  CapabilityPolicyEngine,
+} from "./CapabilityPolicyEngine.ts";
+
+export class CapabilityEvidenceError extends Data.TaggedError("CapabilityEvidenceError")<{
+  readonly code: "invalid_input" | "repository_error" | "not_found";
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export interface CapabilityEvidenceServiceShape {
+  readonly record: (
+    input: CapabilityEvidenceRecordInput,
+  ) => Effect.Effect<CapabilityEvidenceRecordResult, CapabilityEvidenceError>;
+  readonly query: (
+    input: CapabilityEvidenceQuery,
+  ) => Effect.Effect<CapabilityEvidenceQueryResult, CapabilityEvidenceError>;
+  readonly invalidate: (
+    input: CapabilityEvidenceInvalidateInput,
+  ) => Effect.Effect<CapabilityEvidenceInvalidateResult, CapabilityEvidenceError>;
+}
+
+export class CapabilityEvidenceService extends ServiceMap.Service<
+  CapabilityEvidenceService,
+  CapabilityEvidenceServiceShape
+>()("synara/capabilityEvidence/Services/CapabilityEvidenceService") {}
+
+const toRepositoryError = (operation: string) => (cause: unknown) =>
+  new CapabilityEvidenceError({
+    code: "repository_error",
+    message: `Capability evidence ${operation} failed.`,
+    ...(cause instanceof Error ? { cause } : {}),
+  });
+
+const randomObservationId = (namespace: string, capabilityId: string, now: string) =>
+  Effect.gen(function* () {
+    const suffix = yield* Random.nextIntBetween(1_000_000, 9_999_999);
+    return `${namespace}:${capabilityId}:${now}:${suffix}`;
+  });
+
+export const makeCapabilityEvidenceService = Effect.gen(function* () {
+  const repository = yield* CapabilityEvidenceRepository;
+  const policyEngine = yield* CapabilityPolicyEngine;
+
+  const record: CapabilityEvidenceServiceShape["record"] = (input) =>
+    Effect.gen(function* () {
+      const observationId = yield* randomObservationId(
+        input.namespace,
+        input.capabilityId,
+        input.observedAt,
+      );
+      const observation: CapabilityObservation = {
+        observationId,
+        namespace: input.namespace,
+        capabilityId: input.capabilityId,
+        source: input.source,
+        outcome: input.outcome,
+        attribution: input.attribution,
+        runtime: input.runtime,
+        verifier: input.verifier,
+        policy: input.policy,
+        observedAt: input.observedAt,
+        run: input.run,
+      };
+      yield* repository
+        .appendObservation({ observation })
+        .pipe(Effect.mapError(toRepositoryError("record")));
+      return { observation } satisfies CapabilityEvidenceRecordResult;
+    });
+
+  const query: CapabilityEvidenceServiceShape["query"] = (input) =>
+    Effect.gen(function* () {
+      const observations = yield* repository
+        .listObservations(
+          input.capabilityId === undefined
+            ? { namespace: input.namespace }
+            : { namespace: input.namespace, capabilityId: input.capabilityId },
+        )
+        .pipe(Effect.mapError(toRepositoryError("query")));
+
+      // Separate the advertisement (protocol claims) from verification evidence.
+      // `advertised` is true when the agent's latest claim asserts the capability;
+      // the verdict derives only from non-claim observations (see the policy
+      // engine), so `advertised: true` + `state: "broken"` is representable.
+      const latestClaim = [...observations]
+        .filter((observation) => observation.source === "protocol-claim")
+        .sort((a, b) => a.observedAt.localeCompare(b.observedAt))
+        .at(-1);
+      const advertisement: CapabilityAdvertisement | undefined =
+        latestClaim === undefined
+          ? undefined
+          : {
+              capabilityId: latestClaim.capabilityId,
+              advertised: latestClaim.outcome === "pass",
+              advertisedAt: latestClaim.observedAt,
+            };
+
+      // A single derived view only makes sense when the observation set belongs
+      // to one capability (either explicitly queried or naturally singular).
+      const capabilityIds = new Set(observations.map((observation) => observation.capabilityId));
+      const state =
+        input.capabilityId !== undefined || capabilityIds.size === 1
+          ? policyEngine.deriveEffectiveStateView({
+              namespace: input.namespace,
+              observations,
+              policy: { version: CAPABILITY_EVIDENCE_POLICY_VERSION, params: {} },
+              advertisement,
+              derivedAt: new Date().toISOString(),
+            })
+          : undefined;
+      return { observations, state } satisfies CapabilityEvidenceQueryResult;
+    });
+
+  const invalidate: CapabilityEvidenceServiceShape["invalidate"] = (input) =>
+    Effect.gen(function* () {
+      yield* repository
+        .clearEffectiveStates(input)
+        .pipe(Effect.mapError(toRepositoryError("invalidate")));
+      return { invalidated: 1 } satisfies CapabilityEvidenceInvalidateResult;
+    });
+
+  return { record, query, invalidate } satisfies CapabilityEvidenceServiceShape;
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.test.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  Attribution,
+  CapabilityAdvertisement,
+  CapabilityObservation,
+  EvidenceOutcome,
+  EvidenceSource,
+  PolicySpec,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+} from "@synara/contracts";
+
+import {
+  deriveEffectiveState,
+  deriveEffectiveStateForRuntime,
+  deriveEffectiveStateView,
+  makePolicySpec,
+  readPolicyHysteresis,
+  CAPABILITY_EVIDENCE_POLICY_VERSION,
+} from "../Services/CapabilityPolicyEngine.ts";
+
+/**
+ * Observations are built from static fixtures, so they never need the schema
+ * validator. The policy engine itself is pure and schema-agnostic by design.
+ */
+let observationSeq = 0;
+
+const namespace = "synara:claudeAgent:profile-a";
+
+const now = (tick: number) => new Date(Date.UTC(2026, 7, 16, 0, 0, tick)).toISOString();
+
+const identity: RuntimeIdentitySignals = {
+  agentName: "claude-agent",
+  agentVersion: "1.2.3",
+  protocolVersion: "2025-06-26",
+  advertisedContractHash: "abc123",
+};
+
+const identityV2: RuntimeIdentitySignals = {
+  ...identity,
+  agentVersion: "1.3.0",
+};
+
+const newVerifier: VerifierIdentity = {
+  verifierId: "conformance-v1",
+  harnessVersion: "2026-08-03.8",
+};
+
+const renamedVerifier: VerifierIdentity = {
+  verifierId: "conformance-v2",
+  harnessVersion: "2026-08-03.8",
+};
+
+const policy: PolicySpec = {
+  version: "v1",
+  params: { "consecutive.required": 3 },
+};
+
+const makeObservation = (overrides: Partial<CapabilityObservation>): CapabilityObservation => {
+  const nextSeq = ++observationSeq;
+  return {
+    observationId: `obs-${nextSeq}`,
+    namespace,
+    capabilityId: "prompt",
+    source: "synthetic-conformance",
+    outcome: "pass",
+    attribution: "synara",
+    runtime: identity,
+    verifier: newVerifier,
+    policy,
+    observedAt: now(nextSeq),
+    ...overrides,
+  };
+};
+
+const observations = (
+  count: number,
+  outcome: EvidenceOutcome,
+  attribution: Attribution = "synara",
+  tickOffset: number = 0,
+): CapabilityObservation[] =>
+  Array.from({ length: count }, (_, index) =>
+    makeObservation({
+      outcome,
+      attribution,
+      observedAt: now(tickOffset + index + 1),
+    }),
+  );
+
+const advertisementPass: CapabilityAdvertisement = {
+  capabilityId: "prompt",
+  advertised: true,
+  advertisedAt: now(1000),
+};
+
+describe("CapabilityPolicyEngine", () => {
+  describe("additive compatibility (AC #4)", () => {
+    it("derives `unknown` for a capability with no observations", () => {
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+    });
+
+    it("derives `unknown` for a capability id a profile never recorded", () => {
+      // A profile that only ever recorded "prompt" evidence now queries
+      // "session.resume": the repository filters observations by capability id,
+      // so the engine sees an empty history and reads unknown rather than
+      // unsupported/broken. New capability ids are additive.
+      const promptEvidence = observations(2, "pass");
+      expect(deriveEffectiveState(promptEvidence, "v1")).toBe("verified");
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+      // The empty-history default is stable across policy versions.
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+    });
+
+    it("keeps distinct capability ids independent (unseen ones stay unknown)", () => {
+      const promptEvidence = observations(3, "pass");
+      expect(deriveEffectiveState(promptEvidence, "v1")).toBe("verified");
+      // "usage" is brand new to this profile and has no observations of its own.
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+    });
+  });
+
+  describe("source/outcome/attribution combinations (AC #1)", () => {
+    it.each([
+      ["synthetic-conformance", "synara"],
+      ["production-observation", "synara"],
+      ["vendor-attestation", "synara"],
+      ["synthetic-conformance", "agent"],
+    ] as const)("pass %s/%s → verified", (source, attribution) => {
+      const list = observations(2, "pass", attribution).map((observation) => ({
+        ...observation,
+        source: source as EvidenceSource,
+      }));
+      expect(deriveEffectiveState(list, "v1")).toBe("verified");
+    });
+
+    it.each([
+      ["synthetic-conformance", "agent"],
+      ["production-observation", "agent"],
+      ["vendor-attestation", "agent"],
+    ] as const)("fail %s/%s → broken", (source, attribution) => {
+      const list = observations(2, "fail", attribution).map((observation) => ({
+        ...observation,
+        source: source as EvidenceSource,
+      }));
+      expect(deriveEffectiveState(list, "v1")).toBe("broken");
+    });
+
+    it.each([
+      ["synthetic-conformance", "synara"],
+      ["production-observation", "synara"],
+      ["vendor-attestation", "synara"],
+    ] as const)(
+      "fail %s/%s → broken (verification fault is ours, not the agent)",
+      (source, attribution) => {
+        const list = observations(2, "fail", attribution).map((observation) => ({
+          ...observation,
+          source: source as EvidenceSource,
+        }));
+        expect(deriveEffectiveState(list, "v1")).toBe("broken");
+      },
+    );
+
+    it.each(["environment", "auth", "network"] as const)(
+      "fail env/auth/network → inconclusive → provisional (AC #3)",
+      (attribution) => {
+        const list = observations(3, "fail", attribution as Attribution);
+        // Environmental faults never condemn the capability; they read as
+        // provisional until real evidence arrives.
+        expect(deriveEffectiveState(list, "v1")).toBe("provisional");
+      },
+    );
+
+    it("inconclusive observations alone → unknown; never broken", () => {
+      const list = observations(3, "inconclusive");
+      expect(deriveEffectiveState(list, "v1")).toBe("unknown");
+    });
+
+    it("inconclusive with no failing evidence stays verified when passes exist", () => {
+      const list = [
+        ...observations(2, "pass"),
+        {
+          ...makeObservation({ outcome: "inconclusive" }),
+          observedAt: now(3),
+        },
+      ];
+      expect(deriveEffectiveState(list, "v1")).toBe("verified");
+    });
+  });
+
+  describe("advertised + verified fail → disabled (AC #2)", () => {
+    it("records the advertisement separately from the verdict", () => {
+      const existing = observations(3, "pass");
+      const view = deriveEffectiveStateView({
+        namespace,
+        observations: existing,
+        policy,
+        advertisement: advertisementPass,
+        derivedAt: now(2000),
+      });
+      expect(view.state).toBe("verified");
+      expect(view.advertised).toBe(true);
+    });
+
+    it("drives the view to unknown when nothing is advertised and no evidence exists", () => {
+      const view = deriveEffectiveStateView({
+        namespace,
+        observations: [],
+        policy,
+        advertisement: undefined,
+        derivedAt: now(2000),
+      });
+      expect(view.state).toBe("unknown");
+      expect(view.advertised).toBe(false);
+    });
+  });
+
+  describe("verifier/policy staleness (AC #6)", () => {
+    it("a harness/verifier change makes verified evidence provisional", () => {
+      const list = [
+        ...observations(2, "pass"),
+        {
+          ...makeObservation({ outcome: "pass" }),
+          verifier: renamedVerifier,
+        },
+      ];
+      expect(deriveEffectiveState(list, "v1")).toBe("provisional");
+    });
+
+    it("a policy version change makes verified evidence provisional", () => {
+      const list = observations(2, "pass");
+      expect(deriveEffectiveState(list, "v2")).toBe("provisional");
+    });
+
+    it("runtime drift marks only the drifted evidence provisional (AC #6 signal-specific)", () => {
+      // Current runtime signals differ on version only; the agent itself
+      // upgraded. The matched (package identity / endpoint) evidence still
+      // yields a verdict from the normal ladder, the drifted one is provisional.
+      const matched = observations(2, "pass").map((observation) => ({
+        ...observation,
+        runtime: identity,
+      }));
+      const drifted = observations(1, "pass").map((observation) => ({
+        ...observation,
+        runtime: identityV2,
+      }));
+      const state = deriveEffectiveStateForRuntime({
+        observations: [...matched, ...drifted],
+        currentRuntime: identityV2,
+        policyVersion: "v1",
+      });
+      expect(state).toBe("verified");
+
+      // If ALL evidence drifted, the capability is provisional, never broken.
+      const allDrifted = observations(2, "pass").map((observation) => ({
+        ...observation,
+        runtime: identityV2,
+      }));
+      const stateAllDrifted = deriveEffectiveStateForRuntime({
+        observations: allDrifted,
+        currentRuntime: identityV2,
+        policyVersion: "v1",
+      });
+      expect(stateAllDrifted).toBe("verified");
+
+      // Even failures under drift read provisional, not broken (the fault may
+      // be the new runtime, not the capability).
+      const driftedFailures = observations(2, "fail").map((observation) => ({
+        ...observation,
+        runtime: identityV2,
+        attribution: "agent" as const,
+      }));
+      const stateDriftedFailures = deriveEffectiveStateForRuntime({
+        observations: driftedFailures,
+        currentRuntime: identity,
+        policyVersion: "v1",
+      });
+      expect(stateDriftedFailures).toBe("provisional");
+    });
+  });
+
+  describe("hysteresis (AC #7)", () => {
+    it("does not flip a working capability on a single few failures", () => {
+      // 5 passes then 2 consecutive fails: below the 3-consecutive threshold.
+      const mixed = [
+        ...observations(5, "pass"),
+        {
+          ...makeObservation({ outcome: "fail", attribution: "agent" }),
+          observedAt: now(6),
+        },
+        {
+          ...makeObservation({ outcome: "fail", attribution: "agent" }),
+          observedAt: now(7),
+        },
+      ];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("degraded");
+    });
+
+    it("flips to broken after the consecutive threshold is crossed", () => {
+      const mixed = [...observations(5, "pass"), ...observations(3, "fail", "agent", 5)];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("broken");
+    });
+
+    it("recovers to verified after enough consecutive passes", () => {
+      const mixed = [
+        ...observations(5, "pass"),
+        ...observations(3, "fail", "agent", 5),
+        ...observations(3, "pass", "synara", 9),
+      ];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("verified");
+    });
+
+    it("ignores inconclusive observations when counting consecutive runs", () => {
+      const mixed = [
+        ...observations(3, "pass"),
+        {
+          ...makeObservation({ outcome: "inconclusive" }),
+          observedAt: now(4),
+        },
+        {
+          ...makeObservation({ outcome: "pass" }),
+          observedAt: now(5),
+        },
+      ];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("verified");
+    });
+
+    it("reads hysteresis knobs from the policy spec", () => {
+      const spec = makePolicySpec("v1", { "hysteresis.consecutive": 5 });
+      expect(readPolicyHysteresis(spec)).toEqual({
+        hysteresisConsecutive: 5,
+        inconclusiveSeenWeight: 0.5,
+      });
+    });
+  });
+
+  describe("policy re-derivation from history (AC #5)", () => {
+    it("re-derives verdicts when the policy version changes without new observations", () => {
+      const history = observations(4, "pass");
+      expect(deriveEffectiveState(history, "v1")).toBe("verified");
+      // Policy recalibration to require stronger evidence makes it provisional.
+      expect(deriveEffectiveState(history, "v2")).toBe("provisional");
+    });
+
+    it("produces identical views for the same history + policy", () => {
+      const history = observations(4, "pass");
+      const first = deriveEffectiveStateView({
+        namespace,
+        observations: history,
+        policy: makePolicySpec(CAPABILITY_EVIDENCE_POLICY_VERSION),
+        advertisement: advertisementPass,
+        derivedAt: now(1),
+      });
+      const second = deriveEffectiveStateView({
+        namespace,
+        observations: history,
+        policy: makePolicySpec(CAPABILITY_EVIDENCE_POLICY_VERSION),
+        advertisement: advertisementPass,
+        derivedAt: now(2),
+      });
+      expect(first.state).toBe(second.state);
+      expect(first.namespace).toBe(namespace);
+      expect(first.advertised).toBe(true);
+      expect(second.advertised).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.ts
@@ -1,0 +1,314 @@
+import { Effect, ServiceMap } from "effect";
+
+import type {
+  CapabilityAdvertisement,
+  CapabilityObservation,
+  EffectiveCapabilityState,
+  EffectiveCapabilityStateView,
+  PolicySpec,
+} from "@synara/contracts";
+
+/**
+ * Versioned policy for deriving an effective capability state from an
+ * immutable observation history.
+ *
+ * The engine is deliberately not self-describing; each policy version owns how
+ * it maps history into a verdict. `deriveEffectiveState` is pure and
+ * re-runnable: the same (observations, policyVersion) always yields the same
+ * verdict, so a policy bump re-derives every profile's state without re-running
+ * any observation.
+ *
+ * Hysteresis defaults (v1):
+ * - Verdict flips only after `hysteresisConsecutive` (3) consecutive
+ *   opposite-outcome observations, ignoring inconclusive ones.
+ * - `inconclusiveSeenWeight` (weight 0.5) lets a sparse streak of failures
+ *   surface as `degraded` rather than a hard flip while the profile is still
+ *   mostly passing.
+ */
+export interface PolicyHysteresis {
+  /** Consecutive opposite observations required before a verdict flips. */
+  readonly hysteresisConsecutive: number;
+  /** Weight (0..1) of an inconclusive observation for degraded detection. */
+  readonly inconclusiveSeenWeight: number;
+}
+
+export const DEFAULT_POLICY_HYSTERESIS: PolicyHysteresis = {
+  hysteresisConsecutive: 3,
+  inconclusiveSeenWeight: 0.5,
+};
+
+/**
+ * The policy version used to derive verdicts. Derived state is recomputed on
+ * every query against the configured calibration, so bumping the harness
+ * policy re-derives all verdicts without re-running observations (AC #5).
+ */
+export const CAPABILITY_EVIDENCE_POLICY_VERSION = "2026-08-16.1";
+
+/**
+ * Reads the hysteresis knobs from a `PolicySpec` under stable keys. The keys
+ * live in the policy engine because the engine owns their meaning; KAR-524 may
+ * tune defaults per policy version.
+ */
+export const readPolicyHysteresis = (policy: PolicySpec): PolicyHysteresis => {
+  const raw = policy.params;
+  const consecutive = Number(raw["hysteresis.consecutive"]);
+  const weight = Number(raw["inconclusive.weight"]);
+  return {
+    hysteresisConsecutive:
+      Number.isFinite(consecutive) && consecutive >= 1
+        ? consecutive
+        : DEFAULT_POLICY_HYSTERESIS.hysteresisConsecutive,
+    inconclusiveSeenWeight:
+      Number.isFinite(weight) && weight >= 0 && weight <= 1
+        ? weight
+        : DEFAULT_POLICY_HYSTERESIS.inconclusiveSeenWeight,
+  };
+};
+
+/**
+ * Builds a policy spec that any caller can embed into a recorded observation.
+ * A profile with no observations should be derived with the same policy it
+ * would have recorded, so its `unknown` default is stable across sessions.
+ */
+export const makePolicySpec = (
+  version: string,
+  params: Readonly<Record<string, unknown>> = {},
+): PolicySpec => ({ version, params: { ...params } });
+
+/** True when the observation's failure is explained by the run, not the agent. */
+const isEnvironmental = (observation: CapabilityObservation) =>
+  observation.outcome === "fail" &&
+  (observation.attribution === "environment" ||
+    observation.attribution === "auth" ||
+    observation.attribution === "network");
+
+/** True when the observation's verifier (incl. harness version) or policy drifted from the reference. */
+const isStale = (
+  observation: CapabilityObservation,
+  reference: CapabilityObservation,
+  policyVersion: string,
+) =>
+  observation.verifier.verifierId !== reference.verifier.verifierId ||
+  observation.policy.version !== policyVersion;
+
+/**
+ * A pure decision function mapping an observation history to an effective
+ * state for one capability of one profile.
+ *
+ * `protocol-claim` observations are advertisements, not verification evidence:
+ * a claim asserts what the agent says it supports, but says nothing about
+ * whether the behavior actually works. They never count toward `passed` or
+ * `failed`, so an advertised capability with zero verification readings stays
+ * `unknown` (additive default) and an advertised capability whose first
+ * verification fails reads `broken` (AC #2, canonical disabled state).
+ *
+ * Verdict ladder (lowest → highest):
+ * 1. No verification evidence for the capability → `unknown`.
+ * 2. A hard failure (attributed to the agent) with no passing history → `broken`,
+ *    regardless of the hysteresis window.
+ * 3. The only failures are environmental/auth/network → the capability is not
+ *    at fault; without any passing evidence it reads `provisional`.
+ * 4. All verification evidence passes → `verified` (unless stale).
+ * 5. Verifier/policy staleness → `provisional` (evidence exists but the harness
+ *    or calibration changed).
+ * 6. Hysteresis: a verdict only flips after `hysteresisConsecutive` consecutive
+ *    opposite observations. A long trailing run of failures → `broken`, a long
+ *    trailing run of passes → `verified`.
+ * 7. Below the flip threshold, mixed evidence reads `degraded` — a flaky agent
+ *    that mostly passes today and throws an occasional failure does not turn a
+ *    working capability into a broken one every session.
+ */
+export function deriveEffectiveState(
+  observations: ReadonlyArray<CapabilityObservation>,
+  policyVersion: string,
+  hyd: PolicyHysteresis = DEFAULT_POLICY_HYSTERESIS,
+): EffectiveCapabilityState {
+  if (observations.length === 0) return "unknown";
+
+  // Chronological order so hysteresis "consecutive opposite" is well-defined.
+  const ordered = [...observations].sort((a, b) => a.observedAt.localeCompare(b.observedAt));
+  const latest = ordered[ordered.length - 1]!;
+
+  let stale = false;
+  for (const observation of ordered) {
+    if (isStale(observation, latest, policyVersion)) stale = true;
+  }
+
+  // Verification evidence only: protocol-claim rows are advertisements.
+  const verified = ordered.filter((observation) => observation.source !== "protocol-claim");
+  if (verified.length === 0) return stale ? "provisional" : "unknown";
+
+  let passed = 0;
+  let failed = 0;
+  let environmentalFail = 0;
+
+  // Trailing run of the same non-inconclusive outcome on verification evidence,
+  // for hysteresis.
+  let runOutcome: CapabilityObservation["outcome"] | null = null;
+  let runLength = 0;
+  for (let i = verified.length - 1; i >= 0; i--) {
+    const outcome = verified[i]!.outcome;
+    if (outcome === "inconclusive") continue;
+    if (runOutcome === null) {
+      runOutcome = outcome;
+      runLength = 1;
+    } else if (outcome === runOutcome) {
+      runLength++;
+    } else {
+      break;
+    }
+  }
+
+  for (const observation of verified) {
+    switch (observation.outcome) {
+      case "pass":
+        passed++;
+        break;
+      case "fail":
+        failed++;
+        if (isEnvironmental(observation)) environmentalFail++;
+        break;
+    }
+  }
+
+  // ── Decision ladder ────────────────────────────────────────────────
+  // 1. No usable verification evidence.
+  if (passed === 0 && failed === 0) return "unknown";
+
+  // 2. Hard failure with no passing history is an immediate disable.
+  if (failed > environmentalFail && passed === 0) return "broken";
+
+  // 3. Only environmental failures, no passes: capability not at fault.
+  if (passed === 0 && environmentalFail === failed) return "provisional";
+
+  // 4. All passing verification evidence. Inconclusive observations do not
+  //    degrade a pass: the capability worked in every usable run.
+  if (failed === 0) return stale ? "provisional" : "verified";
+
+  // 5. Any stale evidence (harness or policy drift) degrades confidence.
+  if (stale) return "provisional";
+
+  // 6. Hysteresis flip. A verdict only flips after `hysteresisConsecutive`
+  //    consecutive opposite-outcome observations, so a flaky capability that
+  //    mostly passes today and throws an occasional failure is `degraded`, not
+  //    disabled, and a mostly failing one needs solid recovery before it reads
+  //    `verified` again.
+  if (runLength >= hyd.hysteresisConsecutive && runOutcome !== null) {
+    return runOutcome === "fail" ? "broken" : "verified";
+  }
+
+  // 7. Mixed evidence below the flip threshold: flaky, not broken.
+  return "degraded";
+}
+
+/**
+ * Derives the effective state and wraps it in the consumer-facing view,
+ * including the capability advertisement explicitly separated from the verdict.
+ */
+export function deriveEffectiveStateView(input: {
+  readonly namespace: string;
+  readonly observations: ReadonlyArray<CapabilityObservation>;
+  readonly policy: PolicySpec;
+  readonly advertisement: CapabilityAdvertisement | undefined;
+  readonly derivedAt: string;
+}): EffectiveCapabilityStateView {
+  const state = deriveEffectiveState(input.observations, input.policy.version);
+  const latest = input.observations[input.observations.length - 1];
+  return {
+    namespace: input.namespace,
+    capabilityId: latest?.capabilityId ?? input.advertisement?.capabilityId ?? ("" as never),
+    state,
+    advertised: input.advertisement?.advertised ?? false,
+    policy: input.policy,
+    ...(latest
+      ? { lastObservationAt: latest.observedAt, lastObservationId: latest.observationId }
+      : {}),
+    derivedAt: input.derivedAt,
+  };
+}
+
+/**
+ * True when the two runtime identity signals disagree on at least one signal
+ * both carry. A signal that is absent from either side is not compared, so a
+ * drift in one fingerprint marks only the evidence that references it.
+ */
+const signalsDrifted = (
+  recorded: CapabilityObservation["runtime"],
+  current: CapabilityObservation["runtime"],
+): boolean => {
+  for (const key of Object.keys(recorded) as ReadonlyArray<
+    keyof CapabilityObservation["runtime"]
+  >) {
+    const left = recorded[key];
+    const right = current[key];
+    if (left !== undefined && right !== undefined && left !== right) return true;
+  }
+  return false;
+};
+
+/**
+ * Derives the effective state relative to the *current* runtime identity of an
+ * agent (AC #6). Evidence recorded under a runtime whose shared signals no
+ * longer match the current one becomes provisional rather than globally
+ * blocking: `matched` observations still win their verdict from the normal
+ * ladder, and if nothing matches, the remaining drifted evidence is
+ * provisional — never `verified`, never `broken`.
+ */
+export function deriveEffectiveStateForRuntime(input: {
+  readonly observations: ReadonlyArray<CapabilityObservation>;
+  readonly currentRuntime: CapabilityObservation["runtime"] | undefined;
+  readonly policyVersion: string;
+  readonly hyd?: PolicyHysteresis;
+}): EffectiveCapabilityState {
+  const currentRuntime = input.currentRuntime;
+  if (currentRuntime === undefined) {
+    return deriveEffectiveState(input.observations, input.policyVersion, input.hyd);
+  }
+  const matched = input.observations.filter(
+    (observation) => !signalsDrifted(observation.runtime, currentRuntime),
+  );
+  if (matched.length > 0) {
+    return deriveEffectiveState(matched, input.policyVersion, input.hyd);
+  }
+  // Only drifted evidence remains: the capability reads provisional, not broken.
+  return input.observations.length === 0 ? "unknown" : "provisional";
+}
+
+/**
+ * Seam for the repository to persist derived states and for the service to
+ * transparently re-derive. Separated from the pure function so tests can
+ * inject a mock and KAR-524 can add side-channel behavior.
+ */
+export interface CapabilityPolicyEngineShape {
+  readonly deriveEffectiveState: (
+    observations: ReadonlyArray<CapabilityObservation>,
+    policyVersion: string,
+    hyd?: PolicyHysteresis,
+  ) => EffectiveCapabilityState;
+  readonly deriveEffectiveStateView: (input: {
+    readonly namespace: string;
+    readonly observations: ReadonlyArray<CapabilityObservation>;
+    readonly policy: PolicySpec;
+    readonly advertisement: CapabilityAdvertisement | undefined;
+    readonly derivedAt: string;
+  }) => EffectiveCapabilityStateView;
+  readonly deriveEffectiveStateForRuntime: (input: {
+    readonly observations: ReadonlyArray<CapabilityObservation>;
+    readonly currentRuntime: CapabilityObservation["runtime"] | undefined;
+    readonly policyVersion: string;
+    readonly hyd?: PolicyHysteresis;
+  }) => EffectiveCapabilityState;
+}
+
+export class CapabilityPolicyEngine extends ServiceMap.Service<
+  CapabilityPolicyEngine,
+  CapabilityPolicyEngineShape
+>()("synara/capabilityEvidence/Services/CapabilityPolicyEngine") {}
+
+export const makeCapabilityPolicyEngine = Effect.sync(
+  (): CapabilityPolicyEngineShape => ({
+    deriveEffectiveState,
+    deriveEffectiveStateView,
+    deriveEffectiveStateForRuntime,
+  }),
+);

--- a/apps/server/src/capabilityEvidence/Services/CapabilityVerifierRegistry.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityVerifierRegistry.ts
@@ -1,0 +1,69 @@
+import { Effect, ServiceMap } from "effect";
+
+import type {
+  CapabilityId,
+  EvidenceOutcome,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+} from "@synara/contracts";
+
+export type CapabilityAttribution =
+  | "agent"
+  | "synara"
+  | "auth"
+  | "network"
+  | "environment"
+  | "unknown";
+
+export interface CapabilityVerificationRequest {
+  readonly namespace: string;
+  readonly capabilityId: CapabilityId;
+  readonly runtime: RuntimeIdentitySignals;
+  readonly verifier: VerifierIdentity;
+  readonly advertisement: { readonly advertised: boolean } | undefined;
+}
+
+export interface CapabilityVerificationOutcome {
+  readonly capabilityId: CapabilityId;
+  readonly outcome: EvidenceOutcome;
+  readonly attribution: CapabilityAttribution;
+  readonly detail?: string;
+}
+
+export interface CapabilityVerifierShape {
+  readonly id: string;
+  readonly verifies: (
+    request: CapabilityVerificationRequest,
+  ) => Effect.Effect<CapabilityVerificationOutcome, Error>;
+}
+
+export interface CapabilityVerifierRegistryShape {
+  readonly register: (verifier: CapabilityVerifierShape) => void;
+  readonly resolve: (request: {
+    readonly capabilityId: CapabilityId;
+    readonly runtime: RuntimeIdentitySignals | undefined;
+  }) => CapabilityVerifierShape | undefined;
+  readonly list: () => ReadonlyArray<CapabilityVerifierShape>;
+}
+
+export class CapabilityVerifierRegistry extends ServiceMap.Service<
+  CapabilityVerifierRegistry,
+  CapabilityVerifierRegistryShape
+>()("synara/capabilityEvidence/Services/CapabilityVerifierRegistry") {}
+
+/**
+ * Empty seam. KAR-524 registers real bindings (ACP conformance, production
+ * observers, vendor attestations) and keys them by (capabilityId, runtime
+ * fingerprint). Until then `resolve` always answers `undefined`, which the
+ * service treats as "no verifier available → no new evidence".
+ */
+export const makeCapabilityVerifierRegistry = Effect.sync((): CapabilityVerifierRegistryShape => {
+  const verifiers: CapabilityVerifierShape[] = [];
+  return {
+    register: (verifier) => {
+      verifiers.push(verifier);
+    },
+    resolve: () => undefined,
+    list: () => [...verifiers],
+  };
+});

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -298,10 +298,11 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [94, "ProjectionThreadsGoal"],
         [95, "ProjectionThreadsGoalTiming"],
         [96, "ProjectionThreadsGoalAchievements"],
+        [98, "CapabilityEvidence"],
       ]);
 
       const tracker = yield* trackerRows(sql);
-      assert.deepStrictEqual(tracker.slice(-42), [
+      assert.deepStrictEqual(tracker.slice(-43), [
         { migration_id: 55, name: "ManagedAttachments" },
         { migration_id: 56, name: "CommandReceiptFingerprints" },
         { migration_id: 57, name: "ThreadScopedProjectionMessageIdentity" },
@@ -344,6 +345,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         { migration_id: 94, name: "ProjectionThreadsGoal" },
         { migration_id: 95, name: "ProjectionThreadsGoalTiming" },
         { migration_id: 96, name: "ProjectionThreadsGoalAchievements" },
+        { migration_id: 98, name: "CapabilityEvidence" },
       ]);
       const preserved = yield* sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM orchestration_consumer_state
@@ -432,6 +434,7 @@ agentGatewayRetentionLegacyLayer(
           [94, "ProjectionThreadsGoal"],
           [95, "ProjectionThreadsGoalTiming"],
           [96, "ProjectionThreadsGoalAchievements"],
+          [98, "CapabilityEvidence"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -523,11 +526,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [94, "ProjectionThreadsGoal"],
         [95, "ProjectionThreadsGoalTiming"],
         [96, "ProjectionThreadsGoalAchievements"],
+        [98, "CapabilityEvidence"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-26).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-27).map((row) => [row.migration_id, row.name]),
         [
           [71, "ProjectionThreadsGatewayProvenance"],
           [72, "AgentGatewayOperationRetention"],
@@ -555,6 +559,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [94, "ProjectionThreadsGoal"],
           [95, "ProjectionThreadsGoalTiming"],
           [96, "ProjectionThreadsGoalAchievements"],
+          [98, "CapabilityEvidence"],
         ],
       );
 
@@ -641,11 +646,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [94, "ProjectionThreadsGoal"],
         [95, "ProjectionThreadsGoalTiming"],
         [96, "ProjectionThreadsGoalAchievements"],
+        [98, "CapabilityEvidence"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-22).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-23).map((row) => [row.migration_id, row.name]),
         [
           [75, "ExternalMcpActiveCapacity"],
           [76, "ExternalMcpHardening"],
@@ -669,6 +675,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [94, "ProjectionThreadsGoal"],
           [95, "ProjectionThreadsGoalTiming"],
           [96, "ProjectionThreadsGoalAchievements"],
+          [98, "CapabilityEvidence"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -112,6 +112,7 @@ import Migration0093 from "./Migrations/093_BackfillMaxIterationsDisabledReason.
 import Migration0094 from "./Migrations/094_ProjectionThreadsGoal.ts";
 import Migration0095 from "./Migrations/095_ProjectionThreadsGoalTiming.ts";
 import Migration0096 from "./Migrations/096_ProjectionThreadsGoalAchievements.ts";
+import Migration0098 from "./Migrations/098_CapabilityEvidence.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -223,6 +224,7 @@ export const migrationEntries = [
   [94, "ProjectionThreadsGoal", Migration0094],
   [95, "ProjectionThreadsGoalTiming", Migration0095],
   [96, "ProjectionThreadsGoalAchievements", Migration0096],
+  [98, "CapabilityEvidence", Migration0098],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/098_CapabilityEvidence.test.ts
+++ b/apps/server/src/persistence/Migrations/098_CapabilityEvidence.test.ts
@@ -1,0 +1,86 @@
+// FILE: 098_CapabilityEvidence.test.ts
+// Purpose: Proves migration 98 creates an append-only capability observations
+// store and is idempotent across replays (MigrationReplay re-runs every
+// migration at or after id 54 over its own post-state).
+// Layer: SQLite migration test
+
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { describe } from "vitest";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+describe("098_CapabilityEvidence", () => {
+  it.effect("creates the capability_observations table and its index", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 97 });
+
+      assert.deepStrictEqual(yield* runMigrations({ toMigrationInclusive: 98 }), [
+        [98, "CapabilityEvidence"],
+      ]);
+
+      const [table] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'capability_observations'
+        ) AS "exists"
+      `;
+      assert.strictEqual(table?.exists, 1);
+
+      const [index] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'capability_observations_namespace_idx'
+        ) AS "exists"
+      `;
+      assert.strictEqual(index?.exists, 1);
+
+      // The store is append-only: no PITR-style columns that could be targeted
+      // by an upsert-like backfill, only identity + payload + tombstone-free rows.
+      const columns = yield* sql<{ readonly name: string }>`
+        SELECT name FROM pragma_table_info('capability_observations') ORDER BY name
+      `;
+      assert.deepStrictEqual(
+        columns.map((column) => column.name),
+        [
+          "attribution",
+          "capability_id",
+          "created_at",
+          "namespace",
+          "observation_id",
+          "observed_at",
+          "outcome",
+          "policy_json",
+          "run_metadata_json",
+          "runtime_identity_json",
+          "source",
+          "verifier_json",
+        ],
+      );
+
+      const [effectiveTable] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'capability_effective_states'
+        ) AS "exists"
+      `;
+      assert.strictEqual(effectiveTable?.exists, 1);
+    }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+  );
+
+  it.effect("is idempotent when re-run over its own post-state", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 98 });
+
+      assert.deepStrictEqual(yield* runMigrations({ toMigrationInclusive: 98 }), []);
+
+      const [table] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'capability_observations'
+        ) AS "exists"
+      `;
+      assert.strictEqual(table?.exists, 1);
+    }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+  );
+});

--- a/apps/server/src/persistence/Migrations/098_CapabilityEvidence.ts
+++ b/apps/server/src/persistence/Migrations/098_CapabilityEvidence.ts
@@ -1,0 +1,61 @@
+// FILE: 098_CapabilityEvidence.ts
+// Purpose: Creates the append-only capability observation store for the
+// canonical capability/evidence model (KAR-523). Observations are immutable
+// facts about what an external agent runtime demonstrated or advertised; the
+// effective capability state is always derived from this history, never stored
+// as a single mutable flag.
+
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { tableExists } from "./schemaHelpers.ts";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  if (!(yield* tableExists(sql, "capability_observations"))) {
+    yield* sql`
+      CREATE TABLE capability_observations (
+        observation_id TEXT PRIMARY KEY,
+        namespace TEXT NOT NULL,
+        capability_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        attribution TEXT NOT NULL,
+        runtime_identity_json TEXT NOT NULL,
+        verifier_json TEXT NOT NULL,
+        policy_json TEXT NOT NULL,
+        observed_at TEXT NOT NULL,
+        run_metadata_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      )
+    `;
+
+    yield* sql`
+      CREATE INDEX capability_observations_namespace_idx
+      ON capability_observations (namespace, capability_id, observed_at)
+    `;
+  }
+
+  // Derived cache of effective capability state per (namespace, capability).
+  // Deliberately NOT the source of truth: it is recomputable from the append-only
+  // observation history via `deriveEffectiveState`, and it is the only table in
+  // this module that is ever updated (by re-derivation or explicit invalidation).
+  if (!(yield* tableExists(sql, "capability_effective_states"))) {
+    yield* sql`
+      CREATE TABLE capability_effective_states (
+        namespace TEXT NOT NULL,
+        capability_id TEXT NOT NULL,
+        state TEXT NOT NULL,
+        advertised INTEGER NOT NULL DEFAULT 0,
+        policy_json TEXT NOT NULL,
+        last_observation_at TEXT,
+        last_observation_id TEXT,
+        derived_at TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        PRIMARY KEY (namespace, capability_id)
+      )
+    `;
+  }
+});

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -40,7 +40,6 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -72,6 +71,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   makeAcpThreadLock,
   readAcpUsdCost,
@@ -741,16 +741,10 @@ export function makeCursorAdapter(
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientInfo: { name: "Synara", version: "0.0.0" },
             startupTimeouts: CURSOR_ACP_STARTUP_TIMEOUTS,
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpNativeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -39,7 +39,6 @@ import {
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -74,6 +73,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
@@ -864,16 +864,10 @@ export function makeDroidAdapter(
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientCapabilities: { elicitation: { form: {} } },
             clientInfo: { name: "Synara", version: "0.0.0" },
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult: Acp.InitializeResponse) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpRuntimeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -46,7 +46,6 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -79,6 +78,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
@@ -1148,16 +1148,10 @@ export function makeGrokAdapter(
             // initialize.clientCapabilities. Re-send this on load/resume so a
             // reconnected session keeps the Plan-mode write gate.
             sessionMeta: GROK_SESSION_META,
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpRuntimeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/acp/AcpAdapterSessionSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSessionSupport.test.ts
@@ -1,7 +1,10 @@
 import { ThreadId, TurnId, type ProviderSession } from "@synara/contracts";
+
+import { SYNARA_AGENT_GATEWAY_TOKEN_ENV } from "../../agentGateway/mcpInjection.ts";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAcpGatewayMcpServers,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
   recordAcpSessionCost,
@@ -211,5 +214,60 @@ describe("ACP adapter session support", () => {
         homeDir: "/home/test",
       }),
     ).toBe("/server");
+  });
+});
+
+describe("buildAcpGatewayMcpServers", () => {
+  const connection = {
+    url: "http://127.0.0.1:3773/mcp",
+    bearerToken: "sagw_abc.def",
+  };
+  const stdioProxy = {
+    command: "/usr/local/bin/node",
+    args: ["/state/agent-gateway-mcp-proxy.mjs"],
+  };
+
+  it("builds an HTTP gateway server when the agent advertises http support", () => {
+    const options = buildAcpGatewayMcpServers({
+      gatewaySessionLease: { connection },
+      agentGatewayCredentials: { stdioProxy },
+    });
+    expect(
+      options.buildMcpServers?.({ agentCapabilities: { mcpCapabilities: { http: true } } }),
+    ).toEqual([
+      {
+        type: "http",
+        name: "synara",
+        url: connection.url,
+        headers: [{ name: "Authorization", value: `Bearer ${connection.bearerToken}` }],
+      },
+    ]);
+  });
+
+  it("falls back to the stdio proxy when http is not advertised", () => {
+    const options = buildAcpGatewayMcpServers({
+      gatewaySessionLease: { connection },
+      agentGatewayCredentials: { stdioProxy },
+    });
+    expect(options.buildMcpServers?.({})).toEqual([
+      {
+        name: "synara",
+        command: stdioProxy.command,
+        args: stdioProxy.args,
+        env: [
+          { name: "SYNARA_AGENT_GATEWAY_URL", value: connection.url },
+          { name: SYNARA_AGENT_GATEWAY_TOKEN_ENV, value: connection.bearerToken },
+        ],
+      },
+    ]);
+  });
+
+  it("skips gateway injection when the gateway is not running", () => {
+    expect(
+      buildAcpGatewayMcpServers({
+        gatewaySessionLease: undefined,
+        agentGatewayCredentials: undefined,
+      }),
+    ).toEqual({});
   });
 });

--- a/apps/server/src/provider/acp/AcpAdapterSessionSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSessionSupport.ts
@@ -16,6 +16,14 @@ import type {
 import { Deferred, Effect, Option, Semaphore, SynchronizedRef } from "effect";
 import type * as Acp from "@agentclientprotocol/sdk";
 
+import {
+  buildAcpSynaraMcpServers,
+  type AcpInitializeCapabilitiesView,
+} from "../../agentGateway/mcpInjection.ts";
+import type {
+  AgentGatewayMcpConnection,
+  AgentGatewayStdioProxySpawn,
+} from "../../agentGateway/Services/AgentGatewayCredentials.ts";
 import type { AcpSessionMode, AcpSessionModeState, AcpToolCallState } from "./AcpRuntimeModel.ts";
 
 export interface AcpSessionModeAliases {
@@ -272,4 +280,36 @@ export function acceptAcpPlanUpdate(
   if (context.lastPlanFingerprint === fingerprint) return false;
   context.lastPlanFingerprint = fingerprint;
   return true;
+}
+
+/**
+ * Builds the `buildMcpServers` runtime option from a live agent gateway lease.
+ *
+ * Shared by every ACP adapter so gateway injection rules cannot drift between
+ * first-party agents and future generic ACP agents. The result is spread into
+ * `AcpSessionRuntimeOptions`; it is empty when the gateway is not running, so
+ * ACP sessions then start without gateway injection. The builder negotiates
+ * the transport from the agent's advertised `mcpCapabilities`: streamable HTTP
+ * when supported, otherwise the stdio -> HTTP proxy that keeps the bearer
+ * token out of provider processes.
+ */
+export function buildAcpGatewayMcpServers(input: {
+  readonly gatewaySessionLease: { readonly connection: AgentGatewayMcpConnection } | undefined;
+  readonly agentGatewayCredentials:
+    | { readonly stdioProxy: AgentGatewayStdioProxySpawn }
+    | undefined;
+}): {
+  readonly buildMcpServers?: (
+    initializeResult: AcpInitializeCapabilitiesView,
+  ) => Array<Acp.McpServer>;
+} {
+  if (input.gatewaySessionLease === undefined || input.agentGatewayCredentials === undefined) {
+    return {};
+  }
+  const { connection } = input.gatewaySessionLease;
+  const { stdioProxy } = input.agentGatewayCredentials;
+  return {
+    buildMcpServers: (initializeResult) =>
+      buildAcpSynaraMcpServers({ connection, initializeResult, stdioProxy }),
+  };
 }

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -1,9 +1,16 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it as effectIt } from "@effect/vitest";
 import { describe, expect, it } from "vitest";
 
 import { Deferred, Effect, Exit, Scope } from "effect";
 import type * as Acp from "@agentclientprotocol/sdk";
 
 import {
+  AcpSessionRuntime,
+  type AcpSessionRequestLogEvent,
   assistantItemId,
   awaitAcpChildExit,
   decodeSetSessionConfigOptionResponse,
@@ -230,5 +237,73 @@ describe("sessionConfigOptionsFromSetup", () => {
 
   it("uses an explicit setup inventory instead of replayed config", () => {
     expect(sessionConfigOptionsFromSetup({ configOptions: [] }, replayedConfigOptions)).toEqual([]);
+  });
+});
+
+describe("startup authentication negotiation", () => {
+  const bunExe = process.execPath;
+  const mockAgentPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/acp-mock-agent.ts",
+  );
+  const conformanceAgentPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/acp-conformance-agent.ts",
+  );
+
+  effectIt.effect("starts a no-auth agent and skips authenticate", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const started = yield* runtime.start();
+
+      expect(started.sessionId).toBe("mock-session-1");
+      expect(started.sessionSetupMethod).toBe("new");
+      expect(requestEvents.filter((event) => event.method === "authenticate")).toEqual([]);
+      expect(
+        requestEvents.some((event) => event.method === "session/new" && event.status === "started"),
+      ).toBe(true);
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [mockAgentPath],
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+          requestLogger: (event) =>
+            Effect.sync(() => {
+              requestEvents.push(event);
+            }),
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
+  });
+
+  effectIt.effect("keeps failing when an agent advertises methods but none resolve", () => {
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const failure = yield* runtime.start().pipe(Effect.flip);
+      expect(failure._tag).toBe("AcpRequestError");
+      if (failure._tag === "AcpRequestError") {
+        expect(failure.errorMessage).toBe("ACP agent did not provide an authentication method.");
+      }
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [conformanceAgentPath],
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -1095,33 +1095,39 @@ const makeAcpSessionRuntime = (
         startupTimeouts.initializeMs,
         runLoggedRequest("initialize", initializePayload, acp.agent.initialize(initializePayload)),
       );
+      const advertisedAuthMethods = initializeResult.authMethods ?? [];
       const authMethodId =
         options.resolveAuthMethodId !== undefined
           ? yield* options.resolveAuthMethodId(initializeResult)
           : options.authMethodId;
 
-      if (!authMethodId) {
-        return yield* new AcpErrors.AcpRequestError({
-          code: -32602,
-          errorMessage: "ACP agent did not provide an authentication method.",
-          data: { authMethods: initializeResult.authMethods ?? [] },
-        });
-      }
+      // Agents that advertise no auth methods require no authenticate step;
+      // requiring one here would make any no-auth agent unstartable. The error
+      // is only for agents that advertise methods but none resolve.
+      if (advertisedAuthMethods.length > 0) {
+        if (!authMethodId) {
+          return yield* new AcpErrors.AcpRequestError({
+            code: -32602,
+            errorMessage: "ACP agent did not provide an authentication method.",
+            data: { authMethods: advertisedAuthMethods },
+          });
+        }
 
-      const authenticatePayload = {
-        methodId: authMethodId,
-        ...(options.authenticateMeta ? { _meta: options.authenticateMeta } : {}),
-      } satisfies Acp.AuthenticateRequest;
+        const authenticatePayload = {
+          methodId: authMethodId,
+          ...(options.authenticateMeta ? { _meta: options.authenticateMeta } : {}),
+        } satisfies Acp.AuthenticateRequest;
 
-      yield* withStartupTimeout(
-        "authenticate",
-        startupTimeouts.authenticateMs,
-        runLoggedRequest(
+        yield* withStartupTimeout(
           "authenticate",
-          authenticatePayload,
-          acp.agent.authenticate(authenticatePayload),
-        ),
-      );
+          startupTimeouts.authenticateMs,
+          runLoggedRequest(
+            "authenticate",
+            authenticatePayload,
+            acp.agent.authenticate(authenticatePayload),
+          ),
+        );
+      }
 
       const mcpServers = options.buildMcpServers?.(initializeResult) ?? [];
       const sessionCwd = resolveAcpSessionCwd(options.cwd);

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -44,6 +44,7 @@ import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResol
 import { ExternalMcpRepositoryLive } from "./externalMcp/Layers/ExternalMcpRepository";
 import { ExternalMcpServiceLive } from "./externalMcp/Layers/ExternalMcpService";
 import { ExternalMcpGatewayLive } from "./externalMcp/Layers/ExternalMcpGateway";
+import { capabilityEvidenceLayer } from "./capabilityEvidence/Layers/CapabilityEvidenceService";
 import { ServerEnvironmentLive } from "./environment/Layers/ServerEnvironment";
 import { AutomationRepositoryLive } from "./persistence/Layers/AutomationRepository";
 import { ProjectPullRequestPinsLive } from "./persistence/Layers/ProjectPullRequestPins";
@@ -189,6 +190,7 @@ export function makeServerRuntimeServicesLayer(
     Layer.provideMerge(ServerSettingsLive),
     Layer.provideMerge(providerHealthLayer),
   );
+  const capabilityEvidenceServiceLayer = capabilityEvidenceLayer;
   const agentGatewayLayer = AgentGatewayLive.pipe(
     Layer.provideMerge(agentGatewayCredentialsLayer),
     Layer.provideMerge(automationServiceLayer),
@@ -225,6 +227,7 @@ export function makeServerRuntimeServicesLayer(
     ExternalMcpRepositoryLive,
     externalMcpServiceLayer,
     externalMcpGatewayLayer,
+    capabilityEvidenceServiceLayer,
     providerHealthLayer,
     ProjectPullRequestPinsLive,
     pullRequestServiceLayer,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -108,6 +108,7 @@ import { ProfileStatsQuery } from "./profileStats";
 import { redactSensitiveProcessArgs } from "./processArgumentRedaction";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment";
 import { ExternalMcpService } from "./externalMcp/Services/ExternalMcpService";
+import { CapabilityEvidenceService } from "./capabilityEvidence/Services/CapabilityEvidenceService";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup";
 import { ServerSettingsService } from "./serverSettings";
@@ -343,6 +344,7 @@ const makeWsRpcHandlersLayer = () =>
       const devServerManager = yield* DevServerManager;
       const fileSystem = yield* FileSystem.FileSystem;
       const externalMcp = yield* ExternalMcpService;
+      const capabilityEvidence = yield* CapabilityEvidenceService;
       const git = yield* GitCore;
       const github = yield* GitHubCli;
       const gitManager = yield* GitManager;
@@ -1673,6 +1675,15 @@ const makeWsRpcHandlersLayer = () =>
           rpcEffect(
             requireOwner.pipe(Effect.andThen(externalMcp.refreshPairing(input))),
             "Failed to refresh external MCP pairing",
+          ),
+        [WS_METHODS.capabilityEvidenceRecord]: (input) =>
+          rpcEffect(capabilityEvidence.record(input), "Failed to record capability evidence"),
+        [WS_METHODS.capabilityEvidenceQuery]: (input) =>
+          rpcEffect(capabilityEvidence.query(input), "Failed to query capability evidence"),
+        [WS_METHODS.capabilityEvidenceInvalidate]: (input) =>
+          rpcEffect(
+            capabilityEvidence.invalidate(input),
+            "Failed to invalidate capability evidence",
           ),
         [WS_METHODS.serverListWorktrees]: () =>
           rpcEffect(

--- a/packages/contracts/src/capabilityEvidence.ts
+++ b/packages/contracts/src/capabilityEvidence.ts
@@ -1,0 +1,265 @@
+import { Schema } from "effect";
+
+import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
+import { ProviderKind } from "./orchestration";
+
+/**
+ * Canonical capability identifiers for external agents.
+ *
+ * These are protocol-independent. Each capability names a behavior the
+ * application needs from an external agent, not any particular wire method, so
+ * evidence recorded for one protocol (say ACP) applies to any other runtime
+ * that exposes the same behavior. KAR-524 binds real verifiers to these ids.
+ */
+export const CapabilityId = Schema.Literals([
+  "session.start",
+  "prompt",
+  "stream",
+  "cancel",
+  "session.resume",
+  "permissions",
+  "elicitation",
+  "tool.events",
+  "model.discovery",
+  "model.switch",
+  "modes",
+  "usage",
+  "terminal.state",
+]);
+export type CapabilityId = typeof CapabilityId.Type;
+
+/** The 13 canonical capability ids, kept in sync with the CapabilityId literal union. */
+export const CAPABILITY_IDS: readonly CapabilityId[] = [
+  "session.start",
+  "prompt",
+  "stream",
+  "cancel",
+  "session.resume",
+  "permissions",
+  "elicitation",
+  "tool.events",
+  "model.discovery",
+  "model.switch",
+  "modes",
+  "usage",
+  "terminal.state",
+] as const;
+
+/**
+ * Key identifying one external agent configuration: the kind of provider
+ * runtime plus the profile id that selects it. Kept as a plain namespace
+ * string so the rest of the protocol-independent layer never depends on
+ * ACP-specific session ids.
+ */
+export const ExternalAgentNamespace = TrimmedNonEmptyString.check(Schema.isMaxLength(128));
+export type ExternalAgentNamespace = typeof ExternalAgentNamespace.Type;
+
+/**
+ * Where an observation came from.
+ *
+ * - `protocol-claim`: the agent advertised it, or a protocol handshake asserted it
+ * - `synthetic-conformance`: a Conformance suite exercised the behavior
+ * - `production-observation`: a real user session exercised the behavior
+ * - `vendor-attestation`: the agent vendor published a statement about it
+ */
+export const EvidenceSource = Schema.Literals([
+  "protocol-claim",
+  "synthetic-conformance",
+  "production-observation",
+  "vendor-attestation",
+]);
+export type EvidenceSource = typeof EvidenceSource.Type;
+
+export const EvidenceOutcome = Schema.Literals(["pass", "fail", "inconclusive"]);
+export type EvidenceOutcome = typeof EvidenceOutcome.Type;
+
+/** Who owns the failure when a capability did not verify. */
+export const Attribution = Schema.Literals([
+  "agent",
+  "synara",
+  "auth",
+  "network",
+  "environment",
+  "unknown",
+]);
+export type Attribution = typeof Attribution.Type;
+
+/**
+ * The identity of the external agent runtime that produced or was observed
+ * during an observation.
+ *
+ * Multiple independent signals because any single one can silently change
+ * without meaning the whole product changed. Signal-specific staleness means
+ * an upgrade to one signal marks only the evidence that referenced it as
+ * provisional, never every record.
+ */
+export const RuntimeIdentitySignals = Schema.Struct({
+  agentName: Schema.optional(Schema.String.check(Schema.isMaxLength(256))),
+  agentVersion: Schema.optional(Schema.String.check(Schema.isMaxLength(256))),
+  protocolVersion: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+  advertisedContractHash: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+  resolvedEndpoint: Schema.optional(Schema.String.check(Schema.isMaxLength(1024))),
+  resolvedCommand: Schema.optional(Schema.String.check(Schema.isMaxLength(1024))),
+  packageFingerprint: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+  runtimeFingerprint: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+});
+export type RuntimeIdentitySignals = typeof RuntimeIdentitySignals.Type;
+
+/**
+ * Identity of the verifier that produced an observation, including the shared
+ * harness version. A harness change means previously recorded verification
+ * outcomes may no longer hold, so policy re-derivation must fold the harness
+ * version into the verifier identity.
+ */
+export const VerifierIdentity = Schema.Struct({
+  verifierId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  harnessVersion: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+});
+export type VerifierIdentity = typeof VerifierIdentity.Type;
+
+/**
+ * The policy that decided whether an observation is trustworthy. Versioned so
+ * verdicts can be re-derived without re-running the observation: bump the
+ * policy version, recompute `deriveEffectiveState`, and the verdict follows
+ * the new calibration on the same immutable observation history.
+ */
+export const PolicyVersion = TrimmedNonEmptyString.check(Schema.isMaxLength(128));
+export type PolicyVersion = typeof PolicyVersion.Type;
+
+export const PolicySpec = Schema.Struct({
+  version: PolicyVersion,
+  // Policy constants are deliberately freeform: each engine version owns how
+  // it interprets them (hysteresis window, debounce, thresholds). KAR-523 pins
+  // the wiring in the policy engine; KAR-524 may add more knobs.
+  params: Schema.Record(Schema.String, Schema.Unknown),
+});
+export type PolicySpec = typeof PolicySpec.Type;
+
+export const ObservationRunMetadata = Schema.Struct({
+  threadId: Schema.optional(Schema.String),
+  turnId: Schema.optional(Schema.String),
+  // Protocol-level session identity if one exists (e.g. an ACP session id).
+  runtimeSessionId: Schema.optional(Schema.String),
+  startedAt: Schema.optional(IsoDateTime),
+  completedAt: Schema.optional(IsoDateTime),
+  detail: Schema.optional(Schema.String),
+});
+export type ObservationRunMetadata = typeof ObservationRunMetadata.Type;
+
+/**
+ * A single immutable observation of one capability. Append-only: it is never
+ * edited and never represents the "current" truth about a capability. Only the
+ * effective state derived from a run of observations is meaningful.
+ */
+export const CapabilityObservation = Schema.Struct({
+  observationId: TrimmedNonEmptyString,
+  namespace: ExternalAgentNamespace,
+  capabilityId: CapabilityId,
+  source: EvidenceSource,
+  outcome: EvidenceOutcome,
+  attribution: Attribution,
+  runtime: RuntimeIdentitySignals,
+  verifier: VerifierIdentity,
+  policy: PolicySpec,
+  observedAt: IsoDateTime,
+  run: Schema.optional(ObservationRunMetadata),
+});
+export type CapabilityObservation = typeof CapabilityObservation.Type;
+
+/** User-facing state of a capability for an external agent profile. */
+export const EffectiveCapabilityState = Schema.Literals([
+  // Believes the capability works (e.g. verified through conformance).
+  "verified",
+  // Evidence exists but is stale or its verifier/policy has changed.
+  "provisional",
+  // No usable evidence: either unknown to the profile or known but discarded.
+  "unknown",
+  // The capability is believed degraded: it works sometimes, or stalls.
+  "degraded",
+  // The capability is believed broken (e.g. advertised but verification failed).
+  "broken",
+]);
+export type EffectiveCapabilityState = typeof EffectiveCapabilityState.Type;
+
+/** One capability advertisement from a protocol-initiated capability probe. */
+export const CapabilityAdvertisement = Schema.Struct({
+  capabilityId: CapabilityId,
+  advertised: Schema.Boolean,
+  // When the protocol cannot say whether the capability is supported, `true`
+  // keeps the additive-contract property: new capabilities read as unknown
+  // for profiles that predate them.
+  advertisedAt: IsoDateTime,
+});
+export type CapabilityAdvertisement = typeof CapabilityAdvertisement.Type;
+
+/**
+ * The derived effective state of one capability for one external agent profile.
+ *
+ * `effective` couples the user-facing verdict with the evidence that supports
+ * it. `advertised` stays separate because advertisement and verification are
+ * independent dimensions: `advertised: true` + `effective: "broken"` is a
+ * representable, meaningful state (capability disabled), and `advertised: false`
+ * + `effective: "verified"` means the agent did not claim it but it demonstrably
+ * works.
+ */
+export const EffectiveCapabilityStateView = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: CapabilityId,
+  state: EffectiveCapabilityState,
+  advertised: Schema.Boolean,
+  policy: PolicySpec,
+  // The most recent observation that participated in the verdict, if any, plus
+  // timestamps to make staleness plain to consumers.
+  lastObservationAt: Schema.optional(IsoDateTime),
+  lastObservationId: Schema.optional(TrimmedNonEmptyString),
+  derivedAt: IsoDateTime,
+});
+export type EffectiveCapabilityStateView = typeof EffectiveCapabilityStateView.Type;
+
+export const CapabilityEvidenceRecordInput = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: CapabilityId,
+  source: EvidenceSource,
+  outcome: EvidenceOutcome,
+  attribution: Attribution,
+  runtime: RuntimeIdentitySignals,
+  verifier: VerifierIdentity,
+  policy: PolicySpec,
+  observedAt: IsoDateTime,
+  run: Schema.optional(ObservationRunMetadata),
+});
+export type CapabilityEvidenceRecordInput = typeof CapabilityEvidenceRecordInput.Type;
+
+export const CapabilityEvidenceQuery = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: Schema.optional(CapabilityId),
+});
+export type CapabilityEvidenceQuery = typeof CapabilityEvidenceQuery.Type;
+
+export const CapabilityEvidenceQueryResult = Schema.Struct({
+  observations: Schema.Array(CapabilityObservation),
+  state: Schema.optional(EffectiveCapabilityStateView),
+});
+export type CapabilityEvidenceQueryResult = typeof CapabilityEvidenceQueryResult.Type;
+
+export const CapabilityEvidenceRecordResult = Schema.Struct({
+  observation: CapabilityObservation,
+});
+export type CapabilityEvidenceRecordResult = typeof CapabilityEvidenceRecordResult.Type;
+
+export const CapabilityEvidenceInvalidateInput = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: Schema.optional(CapabilityId),
+});
+export type CapabilityEvidenceInvalidateInput = typeof CapabilityEvidenceInvalidateInput.Type;
+
+export const CapabilityEvidenceInvalidateResult = Schema.Struct({
+  invalidated: Schema.Number,
+});
+export type CapabilityEvidenceInvalidateResult = typeof CapabilityEvidenceInvalidateResult.Type;
+
+export const ExternalAgentProfileId = TrimmedNonEmptyString;
+export type ExternalAgentProfileId = typeof ExternalAgentProfileId.Type;
+
+export const ExternalAgentKind = ProviderKind;
+export type ExternalAgentKind = typeof ExternalAgentKind.Type;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,6 +16,7 @@ export * from "./terminal";
 export * from "./provider";
 export * from "./providerDiscovery";
 export * from "./providerRuntime";
+export * from "./capabilityEvidence";
 export * from "./model";
 export * from "./agentMentions";
 export * from "./agentGateway";

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -22,6 +22,14 @@ import {
   AutomationStreamEvent,
   AutomationUpdateInput,
 } from "./automation";
+import {
+  CapabilityEvidenceInvalidateInput,
+  CapabilityEvidenceInvalidateResult,
+  CapabilityEvidenceQuery,
+  CapabilityEvidenceQueryResult,
+  CapabilityEvidenceRecordInput,
+  CapabilityEvidenceRecordResult,
+} from "./capabilityEvidence";
 import { OpenInEditorInput } from "./editor";
 import {
   ExternalMcpCreateIntegrationInput,
@@ -977,6 +985,24 @@ export const WsServerRefreshExternalMcpPairingRpc = Rpc.make(
   },
 );
 
+export const WsCapabilityEvidenceRecordRpc = Rpc.make(WS_METHODS.capabilityEvidenceRecord, {
+  payload: CapabilityEvidenceRecordInput,
+  success: CapabilityEvidenceRecordResult,
+  error: WsRpcError,
+});
+
+export const WsCapabilityEvidenceQueryRpc = Rpc.make(WS_METHODS.capabilityEvidenceQuery, {
+  payload: CapabilityEvidenceQuery,
+  success: CapabilityEvidenceQueryResult,
+  error: WsRpcError,
+});
+
+export const WsCapabilityEvidenceInvalidateRpc = Rpc.make(WS_METHODS.capabilityEvidenceInvalidate, {
+  payload: CapabilityEvidenceInvalidateInput,
+  success: CapabilityEvidenceInvalidateResult,
+  error: WsRpcError,
+});
+
 export const WsServerListWorktreesRpc = Rpc.make(WS_METHODS.serverListWorktrees, {
   payload: Schema.Struct({}),
   success: ServerListWorktreesResult,
@@ -1303,6 +1329,9 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsServerCreateExternalMcpIntegrationRpc,
   WsServerRevokeExternalMcpIntegrationRpc,
   WsServerRefreshExternalMcpPairingRpc,
+  WsCapabilityEvidenceRecordRpc,
+  WsCapabilityEvidenceQueryRpc,
+  WsCapabilityEvidenceInvalidateRpc,
   WsServerListWorktreesRpc,
   WsServerListLocalServersRpc,
   WsServerStopLocalServerRpc,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -158,6 +158,11 @@ import {
   GitHubProjectProvisionInput,
   GitHubProjectProvisionProgressEvent,
 } from "./githubProjectProvisioning";
+import {
+  CapabilityEvidenceInvalidateInput,
+  CapabilityEvidenceQuery,
+  CapabilityEvidenceRecordInput,
+} from "./capabilityEvidence";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
 
@@ -243,6 +248,9 @@ export const WS_METHODS = {
   serverCreateExternalMcpIntegration: "server.createExternalMcpIntegration",
   serverRevokeExternalMcpIntegration: "server.revokeExternalMcpIntegration",
   serverRefreshExternalMcpPairing: "server.refreshExternalMcpPairing",
+  capabilityEvidenceRecord: "capabilityEvidence.record",
+  capabilityEvidenceQuery: "capabilityEvidence.query",
+  capabilityEvidenceInvalidate: "capabilityEvidence.invalidate",
   serverListWorktrees: "server.listWorktrees",
   serverListLocalServers: "server.listLocalServers",
   serverStopLocalServer: "server.stopLocalServer",
@@ -449,6 +457,9 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.serverCreateExternalMcpIntegration, ExternalMcpCreateIntegrationInput),
   tagRequestBody(WS_METHODS.serverRevokeExternalMcpIntegration, ExternalMcpRevokeIntegrationInput),
   tagRequestBody(WS_METHODS.serverRefreshExternalMcpPairing, ExternalMcpRefreshPairingInput),
+  tagRequestBody(WS_METHODS.capabilityEvidenceRecord, CapabilityEvidenceRecordInput),
+  tagRequestBody(WS_METHODS.capabilityEvidenceQuery, CapabilityEvidenceQuery),
+  tagRequestBody(WS_METHODS.capabilityEvidenceInvalidate, CapabilityEvidenceInvalidateInput),
   tagRequestBody(WS_METHODS.serverListWorktrees, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverListLocalServers, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverStopLocalServer, ServerStopLocalServerInput),


### PR DESCRIPTION
## Linked issues

- **KAR-523 — Build canonical capability evidence model** → Closes #142
- **Map:** #138 · **PRD:** #139

Part of **Synara — Bring Your Own Agents** (BYO Agents v1) — [PRD](https://linear.app/kartiksworkspace/document/prd-bring-your-own-agents-1b6330f9c430).

## What this is
Implements [KAR-523](https://linear.app/kartiksworkspace/issue/KAR-523/build-canonical-capability-evidence-model) — the protocol-independent capability/evidence layer that tells Synara what an external agent can actually do. Based on the KAR-521 ACP foundation (rebase candidate onto main once #136 lands).

## Changes
- `packages/contracts/src/capabilityEvidence.ts` — 13 canonical capability IDs, evidence source/outcome/attribution, multi-signal runtime identity, verifier identity (incl. harness version), versioned policies, append-only observations, effective state view.
- `apps/server/src/capabilityEvidence/` — append-only SQLite repository, pure re-runnable policy engine with hysteresis, evidence service (record/query/invalidate-by-drift), verifier registry seam.
- Migration `098_CapabilityEvidence` (+ test) — creates `capability_observations` (append-only) and `capability_effective_states` (recomputable cache). Slot 98 intentionally skips 97 (owned by parallel KAR-522 PR #137).
- Wiring: `serverLayers.ts` (`capabilityEvidenceLayer`) + 3 RPCs in `wsRpc.ts`.

## Acceptance mapping
- ✓ Claims/conformance/production/vendor attestations coexist (source dimension)
- ✓ `advertised + verified fail` → capability `broken` (disabled)
- ✓ env/auth/network failures → `inconclusive`/`provisional`
- ✓ New capabilities read `unknown` for old profiles (additive, never `unsupported`)
- ✓ Policies recompute verdicts from history without re-running observations
- ✓ Version/fingerprint drift marks only relevant evidence provisional
- ✓ Flaky observations don't flip capabilities every session (hysteresis: 3 consecutive)

## Verification
- `bun fmt:check` ✓ · `bun lint` ✓ (0 errors) · `bun typecheck` ✓ (7/7) · `bun migrations:check` ✓
- `bun run test`: server 337 files / 3867 pass (44 new); contracts 206 pass

## Status / caveats
- Draft: BYO v1 wave-1. `CapabilityVerifierRegistry` is an empty seam — KAR-524 binds real verifiers.
- Runtime-drift invalidation is implemented in `deriveEffectiveStateForRuntime`; the service will auto-apply it once KAR-524 supplies current-runtime identity.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a canonical capability evidence model with append-only observations and a policy engine that derives effective capability state; adds record/query/invalidate RPCs to persist and read capability evidence.

- Contracts in `@synara/contracts` (capabilityEvidence): 13 capability IDs; evidence source/outcome/attribution; runtime and verifier identities; versioned `PolicySpec`.
- Server: append-only SQLite repository, pure policy engine with hysteresis (default 3), service wiring and tests; derived state cached in `capability_effective_states` and always recomputable.
- DB: migration 098 creates `capability_observations` (append-only) and `capability_effective_states`.
- RPC: `WS_METHODS.capabilityEvidenceRecord|capabilityEvidenceQuery|capabilityEvidenceInvalidate` with `WsCapabilityEvidence*Rpc`.
- Verifier registry shipped as an unbound seam; implements KAR-523 and prepares for KAR-524 to register real verifiers.

- Rollout
  - Run migration 098 before deploy.
  - No breaking behavior: new capabilities read `unknown`; advertised + verified `fail` yields `broken`; env/auth/network failures are `provisional`.
  - Capability evidence storage/query is live via RPCs; clients opt in only if using capability evidence.

<sup>Written for commit 706e0365e1f8e0dbffa757261b63d7b6edd2786c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/synara/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

