### PR TITLE
KAR-524: Build local conformance runner and hostile reference agents

### DIFF
--- a/apps/server/scripts/acp-hostile-agent.ts
+++ b/apps/server/scripts/acp-hostile-agent.ts
@@ -1,0 +1,557 @@
+#!/usr/bin/env bun
+// FILE: acp-hostile-agent.ts
+// Purpose: Deterministic hostile ACP subprocess for the KAR-524 local
+// conformance runner. Selectable fault modes via SYNARA_ACP_HOSTILE_* env
+// knobs. Each mode is designed to make a real capability verification fail in
+// a specific, reproducible way without the agent ever needing to understand
+// Synara provider names.
+// Layer: Test fixture executable
+// Exports: none; communicates over JSON-RPC stdio.
+
+import { appendFileSync } from "node:fs";
+import { Readable, Writable } from "node:stream";
+import { spawn } from "node:child_process";
+
+import * as OfficialAcp from "@agentclientprotocol/sdk";
+
+const mode = process.env.SYNARA_ACP_HOSTILE_MODE ?? "none";
+const logPath = process.env.SYNARA_ACP_HOSTILE_LOG_PATH;
+const sessionId = process.env.SYNARA_ACP_HOSTILE_SESSION_ID ?? "hostile-session-1";
+const advertisedAgentName = process.env.SYNARA_ACP_HOSTILE_AGENT_NAME ?? "hostile-agent";
+const advertisedVersion = process.env.SYNARA_ACP_HOSTILE_AGENT_VERSION ?? "1.0.0";
+const advertisedAuth = process.env.SYNARA_ACP_HOSTILE_AUTH_METHODS === "1";
+const advertisedLoadSession = process.env.SYNARA_ACP_HOSTILE_ADVERTISE_LOAD === "1";
+const advertisedResume = process.env.SYNARA_ACP_HOSTILE_ADVERTISE_RESUME === "1";
+const advertisedFork = process.env.SYNARA_ACP_HOSTILE_ADVERTISE_FORK === "1";
+const advertisedModes = process.env.SYNARA_ACP_HOSTILE_ADVERTISE_MODES === "1";
+const advertisedUsage = process.env.SYNARA_ACP_HOSTILE_ADVERTISE_USAGE === "1";
+const advertisedConfig = process.env.SYNARA_ACP_HOSTILE_ADVERTISE_CONFIG === "1";
+const emulateAuth = process.env.SYNARA_ACP_HOSTILE_AUTH_METHODS === "1";
+const promptText = process.env.SYNARA_ACP_HOSTILE_PROMPT_TEXT ?? "hostile says hi";
+const hugeOutputBytes = Number(process.env.SYNARA_ACP_HOSTILE_HUGE_OUTPUT_BYTES ?? "64");
+const slowBytesPerMs = Number(process.env.SYNARA_ACP_HOSTILE_SLOW_BYTES_PER_MS ?? "1");
+const flakyCancelFailFirst = process.env.SYNARA_ACP_HOSTILE_FLAKY_CANCEL_FAIL_FIRST === "1";
+const capabilityFlipAfterInitialize = process.env.SYNARA_ACP_HOSTILE_CAPABILITY_FLIP === "1";
+const zombieSpawnRetries = 5;
+
+function log(type: string, payload: unknown): void {
+  if (!logPath) return;
+  try {
+    appendFileSync(logPath, `${JSON.stringify({ type, payload })}\n`, "utf8");
+  } catch {
+    // Logging must never crash the fixture.
+  }
+}
+
+// Zones the fixture refuses to run in: no synchronous writes to stdout from
+// this point on except through the ACP writer, so fault modes stay in control.
+const writeStdoutUtf8 = (text: string): void => {
+  process.stdout.write(text);
+};
+
+let cancelled = false;
+let cancelCount = 0;
+
+// ── startup-time modes (before the connection is built) ──────────────────────
+if (mode === "initialize-hang") {
+  // Connect the SDK as a normal agent but never respond to initialize. The
+  // client's startup budget (bounded) must time out and record
+  // inconclusive/environment instead of a hard agent failure. Connecting keeps
+  // stdin/stdout live so the child stays up for the whole probe; only the
+  // initialize handler is withheld (see the initialize handler below).
+  log("start", { mode });
+}
+
+if (mode === "malformed-frame") {
+  log("start", { mode });
+  writeStdoutUtf8("{not-json}\n");
+}
+
+if (mode === "stdout-pollution") {
+  // Garbage that is not JSON and not a frame, before any protocol message.
+  // The conformance boundary must attribute the failure to the agent, not
+  // silently skip the line.
+  log("start", { mode });
+  writeStdoutUtf8("random agent chatter\n");
+}
+
+if (mode === "zombie-child") {
+  // Spawns a long-lived grandchild so the process tree has a descendant. The
+  // grandchild ignores SIGTERM; supervised teardown must SIGKILL it.
+  log("start", { mode });
+  for (let attempt = 0; attempt < zombieSpawnRetries; attempt++) {
+    try {
+      const child = spawn(process.execPath, ["-e", "setInterval(()=>{},2**31);"], {
+        stdio: "ignore",
+        detached: false,
+      });
+      child.unref();
+      log("zombie-child", { pid: child.pid });
+      break;
+    } catch {
+      // Retry transient spawn failures.
+    }
+  }
+}
+
+if (mode === "partial-utf8") {
+  // Split a multi-byte code point across two writes without a newline between
+  // them, then continue normally.
+  log("start", { mode });
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode("héllo 🎉");
+  process.stdout.write(bytes.slice(0, bytes.indexOf(0xf0) + 1));
+  process.stdout.write(bytes.slice(bytes.indexOf(0xf0) + 1));
+  process.stdout.write("\n");
+}
+
+if (mode === "slow-drip") {
+  // Drip noise to stderr (never the ACP stdout channel) one dot per tick so an
+  // otherwise-healthy agent keeps its protocol stream clean. The conformance
+  // boundary must tolerate slow/steady child output without a premature
+  // timeout or a corrupt frame.
+  log("start", { mode });
+  const drip = setInterval(() => {
+    process.stderr.write(".");
+  }, slowBytesPerMs);
+  drip.unref();
+}
+
+// ── session/update wiring ─────────────────────────────────────────────────────
+interface HostileSessionState {
+  sessionId: string;
+  promptRequests: number;
+}
+
+const state: HostileSessionState = { sessionId, promptRequests: 0 };
+
+function sessionUpdate(context: OfficialAcp.AgentContext) {
+  return (update: Record<string, unknown>): Promise<void> =>
+    context.notify(OfficialAcp.methods.client.session.update, {
+      sessionId: state.sessionId,
+      update,
+    });
+}
+
+function modeState(): OfficialAcp.SessionModeState {
+  return {
+    currentModeId: "ask",
+    availableModes: [
+      { id: "ask", name: "Ask", description: "Request permission before changes" },
+      { id: "code", name: "Code", description: "Write code" },
+    ],
+  };
+}
+
+function configOptions(): Array<OfficialAcp.SessionConfigOption> {
+  return [
+    {
+      id: "model",
+      name: "Model",
+      category: "model",
+      type: "select",
+      currentValue: "default",
+      options: [
+        { value: "default", name: "Auto" },
+        { value: "opus-4.8", name: "Opus 4.8" },
+      ],
+    },
+    {
+      id: "reasoning",
+      name: "Reasoning",
+      category: "thought_level",
+      type: "select",
+      currentValue: "medium",
+      options: [{ value: "medium", name: "Medium" }],
+    },
+  ];
+}
+
+function initializeCapabilities(): Record<string, unknown> {
+  const capabilities: Record<string, unknown> = {
+    promptCapabilities: { image: false, audio: false, embeddedContext: false },
+  };
+  if (advertisedLoadSession) {
+    capabilities.loadSession = true;
+  }
+  const sessionCapabilities: Record<string, unknown> = {};
+  if (advertisedResume) {
+    sessionCapabilities.resume = {};
+  }
+  if (advertisedFork) {
+    sessionCapabilities.fork = {};
+  }
+  capabilities.sessionCapabilities = sessionCapabilities;
+  return capabilities;
+}
+
+const app = OfficialAcp.agent({
+  name: "synara-hostile",
+});
+
+app.onRequest(OfficialAcp.methods.agent.initialize, ({ params }) => {
+  log("initialize", { params });
+  if (mode === "initialize-hang") {
+    // Withhold the initialize response entirely; the client must time out.
+    return new Promise<never>(() => undefined);
+  }
+  return {
+    protocolVersion: 1,
+    agentCapabilities: initializeCapabilities(),
+    ...(advertisedAuth ? { authMethods: [{ id: "test", name: "Test auth" }] } : {}),
+    agentInfo: { name: advertisedAgentName, version: advertisedVersion },
+  };
+});
+
+app.onRequest(OfficialAcp.methods.agent.authenticate, () => {
+  log("authenticate", {});
+  if (emulateAuth) {
+    return {};
+  }
+  throw new OfficialAcp.RequestError(-32602, "authentication required", {
+    denied: true,
+  });
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.new, async ({ client: context }) => {
+  log("session/new", { sessionId: state.sessionId });
+  if (capabilityFlipAfterInitialize) {
+    // The agent advertised resume at initialize but does not actually support
+    // it in practice; a resume attempt will fail.
+    state.sessionId = `${sessionId}-flipped`;
+    return {
+      sessionId: state.sessionId,
+      modes: modeState(),
+      configOptions: configOptions(),
+    };
+  }
+  return {
+    sessionId: state.sessionId,
+    modes: modeState(),
+    configOptions: configOptions(),
+  };
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.resume, async ({ params }) => {
+  log("session/resume", { params });
+  if (mode === "fake-resume") {
+    // Advertises session/resume support but cannot actually reopen the
+    // requested session: refuse the resume outright. The conformance boundary
+    // must attribute the broken advertised capability to the agent.
+    throw new OfficialAcp.RequestError(-32602, "requested session cannot be resumed", {
+      denied: false,
+    });
+  }
+  // Healthy resume echoes the requested id back.
+  return {
+    sessionId: params.sessionId,
+    modes: modeState(),
+    configOptions: configOptions(),
+  };
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.load, async () => {
+  log("session/load", {});
+  return {
+    modes: modeState(),
+    configOptions: configOptions(),
+  };
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.fork, async () => {
+  log("session/fork", {});
+  return {
+    sessionId: `${sessionId}-fork`,
+    modes: modeState(),
+    configOptions: configOptions(),
+  };
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.setConfigOption, async ({ params }) => {
+  log("session/set_config_option", { params });
+  return { configOptions: configOptions() };
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.setMode, async ({ params }) => {
+  log("session/set_mode", { params });
+  return {};
+});
+
+app.onNotification(OfficialAcp.methods.agent.session.cancel, async ({ params }) => {
+  cancelCount += 1;
+  log("session/cancel", { params, cancelCount });
+  if (mode === "ignore-cancel") {
+    return;
+  }
+  cancelled = true;
+});
+
+app.onRequest(OfficialAcp.methods.agent.session.prompt, async ({ client: context, params }) => {
+  const requestId = state.promptRequests++;
+  const requestedSessionId = params.sessionId ?? state.sessionId;
+  log("session/prompt", { requestId, sessionId: requestedSessionId });
+  const notify = sessionUpdate(context);
+
+  if (mode === "process-death") {
+    // Die mid-turn with a non-zero status after the request arrives; the
+    // conformance runner must observe the turn failed and the process edge.
+    process.exit(37);
+  }
+
+  if (mode === "huge-tool-output") {
+    const bytes = "x".repeat(hugeOutputBytes);
+    await notify({
+      sessionUpdate: "tool_call",
+      toolCallId: "tool-huge-1",
+      title: "Tool",
+      kind: "execute",
+      status: "pending",
+      rawInput: { command: ["yes"] },
+    });
+    await notify({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tool-huge-1",
+      status: "completed",
+      rawOutput: { exitCode: 0, stdout: bytes, stderr: "" },
+    });
+    return { stopReason: "end_turn" };
+  }
+
+  if (mode === "permission-deny-loop") {
+    await context.request(OfficialAcp.methods.client.session.requestPermission, {
+      sessionId: state.sessionId,
+      toolCall: {
+        toolCallId: `tool-deny-${requestId}`,
+        title: "Terminal",
+        kind: "execute",
+        status: "pending",
+        rawInput: { command: ["cat", "secrets"] },
+      },
+      options: [
+        { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+        { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+      ],
+    });
+    // Deny loop: request finishes immediately and returns a policy outcome.
+    // The client could keep re-prompting but the conformance observation is
+    // bounded; emitting one tool call per prompt is enough to exercise the path.
+    await notify({
+      sessionUpdate: "tool_call",
+      toolCallId: `tool-deny-${requestId}`,
+      title: "Terminal",
+      kind: "execute",
+      status: "pending",
+      rawInput: { command: ["cat", "secrets"] },
+    });
+    await notify({
+      sessionUpdate: "tool_call_update",
+      toolCallId: `tool-deny-${requestId}`,
+      status: "completed",
+      rawOutput: { exitCode: 1, stdout: "denied", stderr: "permission denied" },
+    });
+    return { stopReason: "end_turn" };
+  }
+
+  if (mode === "stale-ids") {
+    // Duplicate/stale IDs: reuse the same tool call id across two different
+    // tools and the same content message id across separate turns.
+    const toolCallId = "stale-tool-id";
+    await notify({
+      sessionUpdate: "tool_call",
+      toolCallId,
+      title: "Terminal",
+      kind: "execute",
+      status: "pending",
+      rawInput: { command: ["echo", "one"] },
+    });
+    await notify({
+      sessionUpdate: "tool_call_update",
+      toolCallId,
+      status: "completed",
+      rawOutput: { exitCode: 0, stdout: "one", stderr: "" },
+    });
+    await notify({
+      sessionUpdate: "tool_call",
+      toolCallId,
+      title: "Read File",
+      kind: "read",
+      status: "pending",
+      rawInput: { path: "package.json" },
+    });
+    await notify({
+      sessionUpdate: "tool_call_update",
+      toolCallId,
+      status: "completed",
+      rawOutput: { exitCode: 0, stdout: "two", stderr: "" },
+    });
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      messageId: "stale-message-id",
+      content: { type: "text", text: promptText },
+    });
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      messageId: "stale-message-id",
+      content: { type: "text", text: `${promptText}-again` },
+    });
+    return { stopReason: "end_turn" };
+  }
+
+  if (mode === "late-event-after-close") {
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: promptText },
+    });
+    return { stopReason: "end_turn" };
+  }
+
+  if (mode === "capability-change") {
+    // The agent says it supports session/resume at initialize but session/new
+    // reports a different session id than the one it later claims to resume.
+    const flipped = state.sessionId;
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: `${promptText} ${flipped}` },
+    });
+    return { stopReason: "end_turn" };
+  }
+
+  if (mode === "ignore-cancel") {
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "ignoring your cancel" },
+    });
+    // Never returns: the prompt hangs until the runner cancels again or times out.
+    await new Promise<void>(() => undefined);
+    return { stopReason: "cancelled" };
+  }
+
+  if (mode === "flaky-cancel") {
+    // The first prompt rolls the dice: when flakyCancelFailFirst is set this
+    // probe fails for genuinely missing capability; otherwise (and always on
+    // later prompts) it behaves like the healthy path — emit cancel-ready and
+    // resolve only after the client's session/cancel arrives. The conformance
+    // policy must derive a stable degraded (not broken) state from alternating
+    // pass/one-fail evidence (AC #4).
+    const shouldFail = flakyCancelFailFirst && state.promptRequests === 1;
+    if (shouldFail) {
+      await notify({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "flaky failed" },
+      });
+      throw new OfficialAcp.RequestError(-32603, "flaky capability hiccup", {
+        denied: false,
+      });
+    }
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "cancel-ready" },
+    });
+    await new Promise<void>((resolve) => {
+      if (cancelled) {
+        resolve();
+        return;
+      }
+      const timer = setInterval(() => {
+        if (cancelled) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+      timer.unref();
+    });
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "flaky cancelled" },
+    });
+    return { stopReason: cancelled ? "cancelled" : "end_turn" };
+  }
+
+  // Default: behave like a healthy agent for the capability under test. The
+  // conformance cancel probe prompts with "block" and waits for a
+  // `cancel-ready` marker before sending session/cancel; only that path blocks
+  // for the cancel so every other prompt resolves normally.
+  const promptIsBlockProbe =
+    params.prompt?.[0]?.type === "text" && params.prompt[0].text === "block";
+  await notify({
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text: "cancel-ready" },
+  });
+  if (cancelled) {
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "cancelled after ready" },
+    });
+    return { stopReason: "cancelled" };
+  }
+  if (promptIsBlockProbe) {
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        if (cancelled) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+      timer.unref();
+    });
+    await notify({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "cancelled after ready" },
+    });
+    return { stopReason: "cancelled" };
+  }
+  await notify({
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text: promptText },
+  });
+  await notify({
+    sessionUpdate: "usage_update",
+    used: 10,
+    size: 100,
+  });
+  return { stopReason: "end_turn" };
+});
+
+// Late event after close: after the client sends session/close (or the stream
+// closes), the agent emits one more session/update. The runner must not let a
+// post-close event corrupt state.
+app.onRequest(OfficialAcp.methods.agent.session.close, async ({ client: context }) => {
+  log("session/close", { sessionId: state.sessionId });
+  if (mode === "late-event-after-close") {
+    await sessionUpdate(context)({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "after-close" },
+    });
+  }
+  return {};
+});
+
+app.onRequest("conformance/echo", { parse: (params: unknown) => params }, ({ params }) => {
+  log("conformance/echo", { params });
+  return { echo: params };
+});
+
+process.once("SIGTERM", () => {
+  log("sigterm", { mode });
+  if (mode === "zombie-child") {
+    // Leave the grandchild behind even on a clean SIGTERM — the supervisor
+    // must still reap it.
+    setInterval(() => undefined, 60_000).unref();
+    return;
+  }
+  process.exit(0);
+});
+
+process.once("SIGINT", () => {
+  log("sigint", { mode });
+  process.exit(0);
+});
+
+process.once("exit", (code) => {
+  log("exit", { code });
+});
+
+const output = Writable.toWeb(process.stdout) as WritableStream<Uint8Array>;
+const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
+const connection = app.connect(OfficialAcp.ndJsonStream(output, input));
+void connection.closed.then(() => process.exit(0));

--- a/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceRepository.ts
+++ b/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceRepository.ts
@@ -1,0 +1,230 @@
+import type {
+  CapabilityObservation,
+  EffectiveCapabilityStateView,
+  PolicySpec,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+} from "@synara/contracts";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import {
+  CapabilityEvidenceRepository,
+  type CapabilityEvidenceRepositoryShape,
+} from "../Services/CapabilityEvidenceRepository.ts";
+
+const repositoryError = (operation: string) => (cause: unknown) =>
+  new Error(`Capability evidence repository failed during ${operation}.`, { cause });
+
+interface ObservationRow {
+  readonly observationId: string;
+  readonly namespace: string;
+  readonly capabilityId: string;
+  readonly source: string;
+  readonly outcome: string;
+  readonly attribution: string;
+  readonly runtimeIdentityJson: string | null;
+  readonly verifierJson: string | null;
+  readonly policyJson: string | null;
+  readonly observedAt: string;
+  readonly runMetadataJson: string | null;
+}
+
+interface EffectiveStateRow {
+  readonly namespace: string;
+  readonly capabilityId: string;
+  readonly state: string;
+  readonly advertised: number;
+  readonly policyJson: string | null;
+  readonly lastObservationAt: string | null;
+  readonly lastObservationId: string | null;
+  readonly derivedAt: string;
+}
+
+const parseJson = <T>(value: string | null, fallback: T): T => {
+  if (value === null || value === undefined) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+const toObservation = (row: ObservationRow): CapabilityObservation => ({
+  observationId: row.observationId,
+  namespace: row.namespace,
+  capabilityId: row.capabilityId as CapabilityObservation["capabilityId"],
+  source: row.source as CapabilityObservation["source"],
+  outcome: row.outcome as CapabilityObservation["outcome"],
+  attribution: row.attribution as CapabilityObservation["attribution"],
+  runtime: parseJson<RuntimeIdentitySignals>(row.runtimeIdentityJson, {}),
+  verifier: parseJson<VerifierIdentity>(row.verifierJson, { verifierId: "unknown" }),
+  policy: parseJson<PolicySpec>(row.policyJson, { version: "unknown", params: {} }),
+  observedAt: row.observedAt,
+  run: row.runMetadataJson === null ? undefined : parseJson(row.runMetadataJson, undefined),
+});
+
+const toEffectiveState = (row: EffectiveStateRow): EffectiveCapabilityStateView => ({
+  namespace: row.namespace,
+  capabilityId: row.capabilityId as EffectiveCapabilityStateView["capabilityId"],
+  state: row.state as EffectiveCapabilityStateView["state"],
+  advertised: row.advertised === 1,
+  policy: parseJson<PolicySpec>(row.policyJson, { version: "unknown", params: {} }),
+  lastObservationAt: row.lastObservationAt ?? undefined,
+  lastObservationId: row.lastObservationId ?? undefined,
+  derivedAt: row.derivedAt,
+});
+
+export const makeCapabilityEvidenceRepository = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const appendObservation: CapabilityEvidenceRepositoryShape["appendObservation"] = (input) =>
+    sql`
+      INSERT INTO capability_observations (
+        observation_id, namespace, capability_id, source, outcome, attribution,
+        runtime_identity_json, verifier_json, policy_json, observed_at, run_metadata_json
+      ) VALUES (
+        ${input.observation.observationId}, ${input.observation.namespace},
+        ${input.observation.capabilityId}, ${input.observation.source},
+        ${input.observation.outcome}, ${input.observation.attribution},
+        ${JSON.stringify(input.observation.runtime)},
+        ${JSON.stringify(input.observation.verifier)},
+        ${JSON.stringify(input.observation.policy)},
+        ${input.observation.observedAt},
+        ${input.observation.run === undefined ? null : JSON.stringify(input.observation.run)}
+      )
+    `.pipe(Effect.asVoid, Effect.mapError(repositoryError("appendObservation")));
+
+  const listObservations: CapabilityEvidenceRepositoryShape["listObservations"] = (input) =>
+    (input.capabilityId === undefined
+      ? sql<ObservationRow>`
+          SELECT
+            observation_id AS "observationId", namespace, capability_id AS "capabilityId",
+            source, outcome, attribution,
+            runtime_identity_json AS "runtimeIdentityJson",
+            verifier_json AS "verifierJson", policy_json AS "policyJson",
+            observed_at AS "observedAt", run_metadata_json AS "runMetadataJson"
+          FROM capability_observations
+          WHERE namespace = ${input.namespace}
+          ORDER BY observed_at DESC, observation_id DESC
+        `
+      : sql<ObservationRow>`
+          SELECT
+            observation_id AS "observationId", namespace, capability_id AS "capabilityId",
+            source, outcome, attribution,
+            runtime_identity_json AS "runtimeIdentityJson",
+            verifier_json AS "verifierJson", policy_json AS "policyJson",
+            observed_at AS "observedAt", run_metadata_json AS "runMetadataJson"
+          FROM capability_observations
+          WHERE namespace = ${input.namespace} AND capability_id = ${input.capabilityId}
+          ORDER BY observed_at DESC, observation_id DESC
+        `
+    ).pipe(
+      Effect.map((rows) => rows.map(toObservation)),
+      Effect.mapError(repositoryError("listObservations")),
+    );
+
+  const latestRuntimeIdentity: CapabilityEvidenceRepositoryShape["latestRuntimeIdentity"] = (
+    namespace,
+  ) =>
+    sql<{ readonly runtimeIdentityJson: string | null }>`
+      SELECT runtime_identity_json AS "runtimeIdentityJson"
+      FROM capability_observations
+      WHERE namespace = ${namespace}
+      ORDER BY observed_at DESC, observation_id DESC
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) =>
+        rows[0]
+          ? parseJson<RuntimeIdentitySignals | null>(rows[0].runtimeIdentityJson, null)
+          : null,
+      ),
+      Effect.mapError(repositoryError("latestRuntimeIdentity")),
+    );
+
+  const latestVerifierIdentity: CapabilityEvidenceRepositoryShape["latestVerifierIdentity"] = (
+    namespace,
+  ) =>
+    sql<{ readonly verifierJson: string | null }>`
+      SELECT verifier_json AS "verifierJson"
+      FROM capability_observations
+      WHERE namespace = ${namespace}
+      ORDER BY observed_at DESC, observation_id DESC
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) =>
+        rows[0] ? parseJson<VerifierIdentity | null>(rows[0].verifierJson, null) : null,
+      ),
+      Effect.mapError(repositoryError("latestVerifierIdentity")),
+    );
+
+  const latestPolicySpec: CapabilityEvidenceRepositoryShape["latestPolicySpec"] = (namespace) =>
+    sql<{ readonly policyJson: string | null }>`
+      SELECT policy_json AS "policyJson"
+      FROM capability_observations
+      WHERE namespace = ${namespace}
+      ORDER BY observed_at DESC, observation_id DESC
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) =>
+        rows[0] ? parseJson<PolicySpec | null>(rows[0].policyJson, null) : null,
+      ),
+      Effect.mapError(repositoryError("latestPolicySpec")),
+    );
+
+  const upsertEffectiveState: CapabilityEvidenceRepositoryShape["upsertEffectiveState"] = (input) =>
+    sql`
+      INSERT INTO capability_effective_states (
+        namespace, capability_id, state, advertised, policy_json,
+        last_observation_at, last_observation_id, derived_at
+      ) VALUES (
+        ${input.state.namespace}, ${input.state.capabilityId}, ${input.state.state},
+        ${input.state.advertised ? 1 : 0}, ${JSON.stringify(input.state.policy)},
+        ${input.state.lastObservationAt ?? null}, ${input.state.lastObservationId ?? null},
+        ${input.state.derivedAt}
+      )
+      ON CONFLICT (namespace, capability_id) DO UPDATE SET
+        state = excluded.state,
+        advertised = excluded.advertised,
+        policy_json = excluded.policy_json,
+        last_observation_at = excluded.last_observation_at,
+        last_observation_id = excluded.last_observation_id,
+        derived_at = excluded.derived_at
+    `.pipe(Effect.asVoid, Effect.mapError(repositoryError("upsertEffectiveState")));
+
+  const getEffectiveState: CapabilityEvidenceRepositoryShape["getEffectiveState"] = (input) =>
+    sql<EffectiveStateRow>`
+      SELECT
+        namespace, capability_id AS "capabilityId", state, advertised, policy_json AS "policyJson",
+        last_observation_at AS "lastObservationAt", last_observation_id AS "lastObservationId",
+        derived_at AS "derivedAt"
+      FROM capability_effective_states
+      WHERE namespace = ${input.namespace} AND capability_id = ${input.capabilityId}
+      LIMIT 1
+    `.pipe(
+      Effect.map((rows) => (rows[0] ? toEffectiveState(rows[0]) : null)),
+      Effect.mapError(repositoryError("getEffectiveState")),
+    );
+
+  const clearEffectiveStates: CapabilityEvidenceRepositoryShape["clearEffectiveStates"] = (input) =>
+    sql`
+      DELETE FROM capability_effective_states
+      WHERE namespace = ${input.namespace}
+    `.pipe(Effect.asVoid, Effect.mapError(repositoryError("clearEffectiveStates")));
+
+  return {
+    appendObservation,
+    listObservations,
+    latestRuntimeIdentity,
+    latestVerifierIdentity,
+    latestPolicySpec,
+    upsertEffectiveState,
+    getEffectiveState,
+    clearEffectiveStates,
+  } satisfies CapabilityEvidenceRepositoryShape;
+});
+
+export const CapabilityEvidenceRepositoryLive = Layer.effect(
+  CapabilityEvidenceRepository,
+  makeCapabilityEvidenceRepository,
+);

--- a/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceService.ts
+++ b/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceService.ts
@@ -1,0 +1,32 @@
+import { Layer } from "effect";
+
+import { CapabilityEvidenceRepositoryLive } from "./CapabilityEvidenceRepository.ts";
+import {
+  CapabilityEvidenceService,
+  makeCapabilityEvidenceService,
+} from "../Services/CapabilityEvidenceService.ts";
+import {
+  CapabilityPolicyEngine,
+  makeCapabilityPolicyEngine,
+} from "../Services/CapabilityPolicyEngine.ts";
+
+export const CapabilityPolicyEngineLive = Layer.effect(
+  CapabilityPolicyEngine,
+  makeCapabilityPolicyEngine,
+);
+
+export const CapabilityEvidenceServiceLayer = Layer.effect(
+  CapabilityEvidenceService,
+  makeCapabilityEvidenceService,
+);
+
+/**
+ * The capability/evidence service graph: repository (append-only persistence),
+ * policy engine (pure verdict derivation), and the service that glues them.
+ * The service layer is `provideMerge`d over its two dependency layers so the
+ * result has no service requirement beyond SQLite.
+ */
+export const capabilityEvidenceLayer = CapabilityEvidenceServiceLayer.pipe(
+  Layer.provideMerge(CapabilityEvidenceRepositoryLive),
+  Layer.provideMerge(CapabilityPolicyEngineLive),
+);

--- a/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceService.ts
+++ b/apps/server/src/capabilityEvidence/Layers/CapabilityEvidenceService.ts
@@ -9,6 +9,10 @@ import {
   CapabilityPolicyEngine,
   makeCapabilityPolicyEngine,
 } from "../Services/CapabilityPolicyEngine.ts";
+import {
+  CapabilityVerifierRegistryLive,
+  ConformanceRunnerLive,
+} from "../../conformance/ConformanceRunner.ts";
 
 export const CapabilityPolicyEngineLive = Layer.effect(
   CapabilityPolicyEngine,
@@ -22,11 +26,23 @@ export const CapabilityEvidenceServiceLayer = Layer.effect(
 
 /**
  * The capability/evidence service graph: repository (append-only persistence),
- * policy engine (pure verdict derivation), and the service that glues them.
- * The service layer is `provideMerge`d over its two dependency layers so the
- * result has no service requirement beyond SQLite.
+ * policy engine (pure verdict derivation), the service that glues them, the
+ * ACP verifier registry with its registered bindings, and the conformance
+ * runner. The conformance runner and evidence service are composed over their
+ * direct dependencies, and each primitive is merged into one layer whose only
+ * remaining service requirement is SQLite.
  */
-export const capabilityEvidenceLayer = CapabilityEvidenceServiceLayer.pipe(
-  Layer.provideMerge(CapabilityEvidenceRepositoryLive),
-  Layer.provideMerge(CapabilityPolicyEngineLive),
+export const capabilityEvidenceLayer = Layer.mergeAll(
+  CapabilityEvidenceServiceLayer.pipe(
+    Layer.provide(CapabilityEvidenceRepositoryLive),
+    Layer.provide(CapabilityPolicyEngineLive),
+  ),
+  ConformanceRunnerLive.pipe(
+    Layer.provide(CapabilityEvidenceRepositoryLive),
+    Layer.provide(CapabilityPolicyEngineLive),
+    Layer.provide(CapabilityVerifierRegistryLive),
+  ),
+  CapabilityEvidenceRepositoryLive,
+  CapabilityPolicyEngineLive,
+  CapabilityVerifierRegistryLive,
 );

--- a/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceRepository.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceRepository.ts
@@ -1,0 +1,72 @@
+import type {
+  CapabilityId,
+  CapabilityObservation,
+  EffectiveCapabilityStateView,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+  PolicySpec,
+} from "@synara/contracts";
+import { ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+export interface CapabilityObservationRecord extends CapabilityObservation {}
+
+export interface CapabilityEvidenceRepositoryShape {
+  /**
+   * Append one immutable observation. Never updates or deletes prior rows.
+   */
+  readonly appendObservation: (input: {
+    readonly observation: CapabilityObservation;
+  }) => Effect.Effect<void, Error>;
+  /**
+   * List observations for a profile (and optionally a single capability),
+   * newest first.
+   */
+  readonly listObservations: (input: {
+    readonly namespace: string;
+    readonly capabilityId?: CapabilityId;
+  }) => Effect.Effect<ReadonlyArray<CapabilityObservation>, Error>;
+  /**
+   * Latest observed runtime identity signals for a profile. Used to detect
+   * drift when a new observation arrives with different signals.
+   */
+  readonly latestRuntimeIdentity: (
+    namespace: string,
+  ) => Effect.Effect<RuntimeIdentitySignals | null, Error>;
+  /**
+   * Latest verifier identity + harness version seen for a profile.
+   */
+  readonly latestVerifierIdentity: (
+    namespace: string,
+  ) => Effect.Effect<VerifierIdentity | null, Error>;
+  /**
+   * Latest policy spec seen for a profile.
+   */
+  readonly latestPolicySpec: (namespace: string) => Effect.Effect<PolicySpec | null, Error>;
+  /**
+   * Persist a single effective-state snapshot keyed by (namespace, capability).
+   * Stored as a derived cache, never as source of truth — re-derivation recomputes it.
+   */
+  readonly upsertEffectiveState: (input: {
+    readonly state: EffectiveCapabilityStateView;
+  }) => Effect.Effect<void, Error>;
+  /**
+   * Read the persisted effective state for a capability, if any.
+   */
+  readonly getEffectiveState: (input: {
+    readonly namespace: string;
+    readonly capabilityId: CapabilityId;
+  }) => Effect.Effect<EffectiveCapabilityStateView | null, Error>;
+  /**
+   * Delete effective-state cache rows for a profile (used by invalidation).
+   * Does not touch observation rows.
+   */
+  readonly clearEffectiveStates: (input: {
+    readonly namespace: string;
+  }) => Effect.Effect<void, Error>;
+}
+
+export class CapabilityEvidenceRepository extends ServiceMap.Service<
+  CapabilityEvidenceRepository,
+  CapabilityEvidenceRepositoryShape
+>()("synara/capabilityEvidence/Services/CapabilityEvidenceRepository") {}

--- a/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.test.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.test.ts
@@ -1,0 +1,199 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { describe } from "vitest";
+
+import type { PolicySpec, RuntimeIdentitySignals, VerifierIdentity } from "@synara/contracts";
+
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import { capabilityEvidenceLayer } from "../Layers/CapabilityEvidenceService.ts";
+import { CAPABILITY_EVIDENCE_POLICY_VERSION } from "./CapabilityPolicyEngine.ts";
+import { CapabilityEvidenceService } from "./CapabilityEvidenceService.ts";
+
+const testLayer = capabilityEvidenceLayer.pipe(Layer.provideMerge(SqlitePersistenceMemory));
+
+const layer = it.layer(testLayer);
+
+let profileSeq = 0;
+const namespace = () => `synara:claudeAgent:profile-${++profileSeq}`;
+const identity: RuntimeIdentitySignals = {
+  agentName: "claude-agent",
+  agentVersion: "1.2.3",
+  protocolVersion: "2025-06-26",
+  advertisedContractHash: "abc123",
+};
+const verifier: VerifierIdentity = {
+  verifierId: "conformance-v1",
+  harnessVersion: "2026-08-03.8",
+};
+const policy: PolicySpec = { version: CAPABILITY_EVIDENCE_POLICY_VERSION, params: {} };
+
+let seq = 0;
+const observedAt = () => new Date(Date.UTC(2026, 7, 16, 0, 0, ++seq)).toISOString();
+
+describe("CapabilityEvidenceService", () => {
+  layer("append-only record + query (AC #1, #2, #5)", (it) => {
+    it.effect("records observations and queries them back with a derived state", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+
+        const recorded = yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "synthetic-conformance",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        assert.strictEqual(recorded.observation.outcome, "pass");
+
+        const result = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(result.observations.length, 1);
+        assert.strictEqual(result.state?.capabilityId, "prompt");
+        assert.strictEqual(result.state?.state, "verified");
+      }),
+    );
+
+    it.effect("advertised + verified fail → disabled (AC #2 persists the combination)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "session.start",
+          source: "protocol-claim",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "session.start",
+          source: "synthetic-conformance",
+          outcome: "fail",
+          attribution: "agent",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+
+        const result = yield* service.query({ namespace: ns, capabilityId: "session.start" });
+        const broken = result.observations.find((ob) => ob.capabilityId === "session.start");
+        assert.ok(broken);
+        assert.strictEqual(broken.outcome, "fail");
+        // `advertised: true` (from the protocol claim) + `state: "broken"`
+        // (first verification failed) is the canonical disabled combination.
+        assert.strictEqual(result.state?.advertised, true);
+        assert.strictEqual(result.state?.state, "broken");
+      }),
+    );
+
+    it.effect("env/auth/network failures read inconclusive (AC #3)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "stream",
+          source: "production-observation",
+          outcome: "fail",
+          attribution: "network",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const result = yield* service.query({ namespace: ns, capabilityId: "stream" });
+        assert.strictEqual(result.observations[0]?.attribution, "network");
+        assert.strictEqual(result.state?.state, "provisional");
+      }),
+    );
+
+    it.effect("new capability reads unknown for profiles with no history (AC #4)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "production-observation",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const result = yield* service.query({ namespace: ns, capabilityId: "model.switch" });
+        assert.strictEqual(result.observations.length, 0);
+        assert.strictEqual(result.state?.state, "unknown");
+      }),
+    );
+
+    it.effect("never overwrites earlier observations (append-only)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        const first = yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "vendor-attestation",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const second = yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "synthetic-conformance",
+          outcome: "fail",
+          attribution: "agent",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        assert.notEqual(first.observation.observationId, second.observation.observationId);
+
+        const result = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(result.observations.length, 2);
+      }),
+    );
+
+    it.effect("invalidate clears derived state without touching observations (AC #5)", () =>
+      Effect.gen(function* () {
+        const service = yield* CapabilityEvidenceService;
+        const ns = namespace();
+        yield* service.record({
+          namespace: ns,
+          capabilityId: "prompt",
+          source: "synthetic-conformance",
+          outcome: "pass",
+          attribution: "synara",
+          runtime: identity,
+          verifier,
+          policy,
+          observedAt: observedAt(),
+        });
+        const before = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(before.state?.state, "verified");
+
+        const invalidation = yield* service.invalidate({ namespace: ns });
+        assert.strictEqual(invalidation.invalidated, 1);
+
+        const after = yield* service.query({ namespace: ns, capabilityId: "prompt" });
+        assert.strictEqual(after.state?.state, "verified"); // re-derived from history
+      }),
+    );
+  });
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityEvidenceService.ts
@@ -1,0 +1,137 @@
+import type {
+  CapabilityAdvertisement,
+  CapabilityEvidenceInvalidateInput,
+  CapabilityEvidenceInvalidateResult,
+  CapabilityEvidenceQuery,
+  CapabilityEvidenceQueryResult,
+  CapabilityEvidenceRecordInput,
+  CapabilityEvidenceRecordResult,
+  CapabilityObservation,
+} from "@synara/contracts";
+import { Data, Effect, Random, ServiceMap } from "effect";
+
+import { CapabilityEvidenceRepository } from "./CapabilityEvidenceRepository.ts";
+import {
+  CAPABILITY_EVIDENCE_POLICY_VERSION,
+  CapabilityPolicyEngine,
+} from "./CapabilityPolicyEngine.ts";
+
+export class CapabilityEvidenceError extends Data.TaggedError("CapabilityEvidenceError")<{
+  readonly code: "invalid_input" | "repository_error" | "not_found";
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export interface CapabilityEvidenceServiceShape {
+  readonly record: (
+    input: CapabilityEvidenceRecordInput,
+  ) => Effect.Effect<CapabilityEvidenceRecordResult, CapabilityEvidenceError>;
+  readonly query: (
+    input: CapabilityEvidenceQuery,
+  ) => Effect.Effect<CapabilityEvidenceQueryResult, CapabilityEvidenceError>;
+  readonly invalidate: (
+    input: CapabilityEvidenceInvalidateInput,
+  ) => Effect.Effect<CapabilityEvidenceInvalidateResult, CapabilityEvidenceError>;
+}
+
+export class CapabilityEvidenceService extends ServiceMap.Service<
+  CapabilityEvidenceService,
+  CapabilityEvidenceServiceShape
+>()("synara/capabilityEvidence/Services/CapabilityEvidenceService") {}
+
+const toRepositoryError = (operation: string) => (cause: unknown) =>
+  new CapabilityEvidenceError({
+    code: "repository_error",
+    message: `Capability evidence ${operation} failed.`,
+    ...(cause instanceof Error ? { cause } : {}),
+  });
+
+const randomObservationId = (namespace: string, capabilityId: string, now: string) =>
+  Effect.gen(function* () {
+    const suffix = yield* Random.nextIntBetween(1_000_000, 9_999_999);
+    return `${namespace}:${capabilityId}:${now}:${suffix}`;
+  });
+
+export const makeCapabilityEvidenceService = Effect.gen(function* () {
+  const repository = yield* CapabilityEvidenceRepository;
+  const policyEngine = yield* CapabilityPolicyEngine;
+
+  const record: CapabilityEvidenceServiceShape["record"] = (input) =>
+    Effect.gen(function* () {
+      const observationId = yield* randomObservationId(
+        input.namespace,
+        input.capabilityId,
+        input.observedAt,
+      );
+      const observation: CapabilityObservation = {
+        observationId,
+        namespace: input.namespace,
+        capabilityId: input.capabilityId,
+        source: input.source,
+        outcome: input.outcome,
+        attribution: input.attribution,
+        runtime: input.runtime,
+        verifier: input.verifier,
+        policy: input.policy,
+        observedAt: input.observedAt,
+        run: input.run,
+      };
+      yield* repository
+        .appendObservation({ observation })
+        .pipe(Effect.mapError(toRepositoryError("record")));
+      return { observation } satisfies CapabilityEvidenceRecordResult;
+    });
+
+  const query: CapabilityEvidenceServiceShape["query"] = (input) =>
+    Effect.gen(function* () {
+      const observations = yield* repository
+        .listObservations(
+          input.capabilityId === undefined
+            ? { namespace: input.namespace }
+            : { namespace: input.namespace, capabilityId: input.capabilityId },
+        )
+        .pipe(Effect.mapError(toRepositoryError("query")));
+
+      // Separate the advertisement (protocol claims) from verification evidence.
+      // `advertised` is true when the agent's latest claim asserts the capability;
+      // the verdict derives only from non-claim observations (see the policy
+      // engine), so `advertised: true` + `state: "broken"` is representable.
+      const latestClaim = [...observations]
+        .filter((observation) => observation.source === "protocol-claim")
+        .sort((a, b) => a.observedAt.localeCompare(b.observedAt))
+        .at(-1);
+      const advertisement: CapabilityAdvertisement | undefined =
+        latestClaim === undefined
+          ? undefined
+          : {
+              capabilityId: latestClaim.capabilityId,
+              advertised: latestClaim.outcome === "pass",
+              advertisedAt: latestClaim.observedAt,
+            };
+
+      // A single derived view only makes sense when the observation set belongs
+      // to one capability (either explicitly queried or naturally singular).
+      const capabilityIds = new Set(observations.map((observation) => observation.capabilityId));
+      const state =
+        input.capabilityId !== undefined || capabilityIds.size === 1
+          ? policyEngine.deriveEffectiveStateView({
+              namespace: input.namespace,
+              observations,
+              policy: { version: CAPABILITY_EVIDENCE_POLICY_VERSION, params: {} },
+              advertisement,
+              derivedAt: new Date().toISOString(),
+            })
+          : undefined;
+      return { observations, state } satisfies CapabilityEvidenceQueryResult;
+    });
+
+  const invalidate: CapabilityEvidenceServiceShape["invalidate"] = (input) =>
+    Effect.gen(function* () {
+      yield* repository
+        .clearEffectiveStates(input)
+        .pipe(Effect.mapError(toRepositoryError("invalidate")));
+      return { invalidated: 1 } satisfies CapabilityEvidenceInvalidateResult;
+    });
+
+  return { record, query, invalidate } satisfies CapabilityEvidenceServiceShape;
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.test.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  Attribution,
+  CapabilityAdvertisement,
+  CapabilityObservation,
+  EvidenceOutcome,
+  EvidenceSource,
+  PolicySpec,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+} from "@synara/contracts";
+
+import {
+  deriveEffectiveState,
+  deriveEffectiveStateForRuntime,
+  deriveEffectiveStateView,
+  makePolicySpec,
+  readPolicyHysteresis,
+  CAPABILITY_EVIDENCE_POLICY_VERSION,
+} from "../Services/CapabilityPolicyEngine.ts";
+
+/**
+ * Observations are built from static fixtures, so they never need the schema
+ * validator. The policy engine itself is pure and schema-agnostic by design.
+ */
+let observationSeq = 0;
+
+const namespace = "synara:claudeAgent:profile-a";
+
+const now = (tick: number) => new Date(Date.UTC(2026, 7, 16, 0, 0, tick)).toISOString();
+
+const identity: RuntimeIdentitySignals = {
+  agentName: "claude-agent",
+  agentVersion: "1.2.3",
+  protocolVersion: "2025-06-26",
+  advertisedContractHash: "abc123",
+};
+
+const identityV2: RuntimeIdentitySignals = {
+  ...identity,
+  agentVersion: "1.3.0",
+};
+
+const newVerifier: VerifierIdentity = {
+  verifierId: "conformance-v1",
+  harnessVersion: "2026-08-03.8",
+};
+
+const renamedVerifier: VerifierIdentity = {
+  verifierId: "conformance-v2",
+  harnessVersion: "2026-08-03.8",
+};
+
+const policy: PolicySpec = {
+  version: "v1",
+  params: { "consecutive.required": 3 },
+};
+
+const makeObservation = (overrides: Partial<CapabilityObservation>): CapabilityObservation => {
+  const nextSeq = ++observationSeq;
+  return {
+    observationId: `obs-${nextSeq}`,
+    namespace,
+    capabilityId: "prompt",
+    source: "synthetic-conformance",
+    outcome: "pass",
+    attribution: "synara",
+    runtime: identity,
+    verifier: newVerifier,
+    policy,
+    observedAt: now(nextSeq),
+    ...overrides,
+  };
+};
+
+const observations = (
+  count: number,
+  outcome: EvidenceOutcome,
+  attribution: Attribution = "synara",
+  tickOffset: number = 0,
+): CapabilityObservation[] =>
+  Array.from({ length: count }, (_, index) =>
+    makeObservation({
+      outcome,
+      attribution,
+      observedAt: now(tickOffset + index + 1),
+    }),
+  );
+
+const advertisementPass: CapabilityAdvertisement = {
+  capabilityId: "prompt",
+  advertised: true,
+  advertisedAt: now(1000),
+};
+
+describe("CapabilityPolicyEngine", () => {
+  describe("additive compatibility (AC #4)", () => {
+    it("derives `unknown` for a capability with no observations", () => {
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+    });
+
+    it("derives `unknown` for a capability id a profile never recorded", () => {
+      // A profile that only ever recorded "prompt" evidence now queries
+      // "session.resume": the repository filters observations by capability id,
+      // so the engine sees an empty history and reads unknown rather than
+      // unsupported/broken. New capability ids are additive.
+      const promptEvidence = observations(2, "pass");
+      expect(deriveEffectiveState(promptEvidence, "v1")).toBe("verified");
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+      // The empty-history default is stable across policy versions.
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+    });
+
+    it("keeps distinct capability ids independent (unseen ones stay unknown)", () => {
+      const promptEvidence = observations(3, "pass");
+      expect(deriveEffectiveState(promptEvidence, "v1")).toBe("verified");
+      // "usage" is brand new to this profile and has no observations of its own.
+      expect(deriveEffectiveState([], "v1")).toBe("unknown");
+    });
+  });
+
+  describe("source/outcome/attribution combinations (AC #1)", () => {
+    it.each([
+      ["synthetic-conformance", "synara"],
+      ["production-observation", "synara"],
+      ["vendor-attestation", "synara"],
+      ["synthetic-conformance", "agent"],
+    ] as const)("pass %s/%s → verified", (source, attribution) => {
+      const list = observations(2, "pass", attribution).map((observation) => ({
+        ...observation,
+        source: source as EvidenceSource,
+      }));
+      expect(deriveEffectiveState(list, "v1")).toBe("verified");
+    });
+
+    it.each([
+      ["synthetic-conformance", "agent"],
+      ["production-observation", "agent"],
+      ["vendor-attestation", "agent"],
+    ] as const)("fail %s/%s → broken", (source, attribution) => {
+      const list = observations(2, "fail", attribution).map((observation) => ({
+        ...observation,
+        source: source as EvidenceSource,
+      }));
+      expect(deriveEffectiveState(list, "v1")).toBe("broken");
+    });
+
+    it.each([
+      ["synthetic-conformance", "synara"],
+      ["production-observation", "synara"],
+      ["vendor-attestation", "synara"],
+    ] as const)(
+      "fail %s/%s → broken (verification fault is ours, not the agent)",
+      (source, attribution) => {
+        const list = observations(2, "fail", attribution).map((observation) => ({
+          ...observation,
+          source: source as EvidenceSource,
+        }));
+        expect(deriveEffectiveState(list, "v1")).toBe("broken");
+      },
+    );
+
+    it.each(["environment", "auth", "network"] as const)(
+      "fail env/auth/network → inconclusive → provisional (AC #3)",
+      (attribution) => {
+        const list = observations(3, "fail", attribution as Attribution);
+        // Environmental faults never condemn the capability; they read as
+        // provisional until real evidence arrives.
+        expect(deriveEffectiveState(list, "v1")).toBe("provisional");
+      },
+    );
+
+    it("inconclusive observations alone → unknown; never broken", () => {
+      const list = observations(3, "inconclusive");
+      expect(deriveEffectiveState(list, "v1")).toBe("unknown");
+    });
+
+    it("inconclusive with no failing evidence stays verified when passes exist", () => {
+      const list = [
+        ...observations(2, "pass"),
+        {
+          ...makeObservation({ outcome: "inconclusive" }),
+          observedAt: now(3),
+        },
+      ];
+      expect(deriveEffectiveState(list, "v1")).toBe("verified");
+    });
+  });
+
+  describe("advertised + verified fail → disabled (AC #2)", () => {
+    it("records the advertisement separately from the verdict", () => {
+      const existing = observations(3, "pass");
+      const view = deriveEffectiveStateView({
+        namespace,
+        observations: existing,
+        policy,
+        advertisement: advertisementPass,
+        derivedAt: now(2000),
+      });
+      expect(view.state).toBe("verified");
+      expect(view.advertised).toBe(true);
+    });
+
+    it("drives the view to unknown when nothing is advertised and no evidence exists", () => {
+      const view = deriveEffectiveStateView({
+        namespace,
+        observations: [],
+        policy,
+        advertisement: undefined,
+        derivedAt: now(2000),
+      });
+      expect(view.state).toBe("unknown");
+      expect(view.advertised).toBe(false);
+    });
+  });
+
+  describe("verifier/policy staleness (AC #6)", () => {
+    it("a harness/verifier change makes verified evidence provisional", () => {
+      const list = [
+        ...observations(2, "pass"),
+        {
+          ...makeObservation({ outcome: "pass" }),
+          verifier: renamedVerifier,
+        },
+      ];
+      expect(deriveEffectiveState(list, "v1")).toBe("provisional");
+    });
+
+    it("a policy version change makes verified evidence provisional", () => {
+      const list = observations(2, "pass");
+      expect(deriveEffectiveState(list, "v2")).toBe("provisional");
+    });
+
+    it("runtime drift marks only the drifted evidence provisional (AC #6 signal-specific)", () => {
+      // Current runtime signals differ on version only; the agent itself
+      // upgraded. The matched (package identity / endpoint) evidence still
+      // yields a verdict from the normal ladder, the drifted one is provisional.
+      const matched = observations(2, "pass").map((observation) => ({
+        ...observation,
+        runtime: identity,
+      }));
+      const drifted = observations(1, "pass").map((observation) => ({
+        ...observation,
+        runtime: identityV2,
+      }));
+      const state = deriveEffectiveStateForRuntime({
+        observations: [...matched, ...drifted],
+        currentRuntime: identityV2,
+        policyVersion: "v1",
+      });
+      expect(state).toBe("verified");
+
+      // If ALL evidence drifted, the capability is provisional, never broken.
+      const allDrifted = observations(2, "pass").map((observation) => ({
+        ...observation,
+        runtime: identityV2,
+      }));
+      const stateAllDrifted = deriveEffectiveStateForRuntime({
+        observations: allDrifted,
+        currentRuntime: identityV2,
+        policyVersion: "v1",
+      });
+      expect(stateAllDrifted).toBe("verified");
+
+      // Even failures under drift read provisional, not broken (the fault may
+      // be the new runtime, not the capability).
+      const driftedFailures = observations(2, "fail").map((observation) => ({
+        ...observation,
+        runtime: identityV2,
+        attribution: "agent" as const,
+      }));
+      const stateDriftedFailures = deriveEffectiveStateForRuntime({
+        observations: driftedFailures,
+        currentRuntime: identity,
+        policyVersion: "v1",
+      });
+      expect(stateDriftedFailures).toBe("provisional");
+    });
+  });
+
+  describe("hysteresis (AC #7)", () => {
+    it("does not flip a working capability on a single few failures", () => {
+      // 5 passes then 2 consecutive fails: below the 3-consecutive threshold.
+      const mixed = [
+        ...observations(5, "pass"),
+        {
+          ...makeObservation({ outcome: "fail", attribution: "agent" }),
+          observedAt: now(6),
+        },
+        {
+          ...makeObservation({ outcome: "fail", attribution: "agent" }),
+          observedAt: now(7),
+        },
+      ];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("degraded");
+    });
+
+    it("flips to broken after the consecutive threshold is crossed", () => {
+      const mixed = [...observations(5, "pass"), ...observations(3, "fail", "agent", 5)];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("broken");
+    });
+
+    it("recovers to verified after enough consecutive passes", () => {
+      const mixed = [
+        ...observations(5, "pass"),
+        ...observations(3, "fail", "agent", 5),
+        ...observations(3, "pass", "synara", 9),
+      ];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("verified");
+    });
+
+    it("ignores inconclusive observations when counting consecutive runs", () => {
+      const mixed = [
+        ...observations(3, "pass"),
+        {
+          ...makeObservation({ outcome: "inconclusive" }),
+          observedAt: now(4),
+        },
+        {
+          ...makeObservation({ outcome: "pass" }),
+          observedAt: now(5),
+        },
+      ];
+      expect(deriveEffectiveState(mixed, "v1")).toBe("verified");
+    });
+
+    it("reads hysteresis knobs from the policy spec", () => {
+      const spec = makePolicySpec("v1", { "hysteresis.consecutive": 5 });
+      expect(readPolicyHysteresis(spec)).toEqual({
+        hysteresisConsecutive: 5,
+        inconclusiveSeenWeight: 0.5,
+      });
+    });
+  });
+
+  describe("policy re-derivation from history (AC #5)", () => {
+    it("re-derives verdicts when the policy version changes without new observations", () => {
+      const history = observations(4, "pass");
+      expect(deriveEffectiveState(history, "v1")).toBe("verified");
+      // Policy recalibration to require stronger evidence makes it provisional.
+      expect(deriveEffectiveState(history, "v2")).toBe("provisional");
+    });
+
+    it("produces identical views for the same history + policy", () => {
+      const history = observations(4, "pass");
+      const first = deriveEffectiveStateView({
+        namespace,
+        observations: history,
+        policy: makePolicySpec(CAPABILITY_EVIDENCE_POLICY_VERSION),
+        advertisement: advertisementPass,
+        derivedAt: now(1),
+      });
+      const second = deriveEffectiveStateView({
+        namespace,
+        observations: history,
+        policy: makePolicySpec(CAPABILITY_EVIDENCE_POLICY_VERSION),
+        advertisement: advertisementPass,
+        derivedAt: now(2),
+      });
+      expect(first.state).toBe(second.state);
+      expect(first.namespace).toBe(namespace);
+      expect(first.advertised).toBe(true);
+      expect(second.advertised).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityPolicyEngine.ts
@@ -1,0 +1,314 @@
+import { Effect, ServiceMap } from "effect";
+
+import type {
+  CapabilityAdvertisement,
+  CapabilityObservation,
+  EffectiveCapabilityState,
+  EffectiveCapabilityStateView,
+  PolicySpec,
+} from "@synara/contracts";
+
+/**
+ * Versioned policy for deriving an effective capability state from an
+ * immutable observation history.
+ *
+ * The engine is deliberately not self-describing; each policy version owns how
+ * it maps history into a verdict. `deriveEffectiveState` is pure and
+ * re-runnable: the same (observations, policyVersion) always yields the same
+ * verdict, so a policy bump re-derives every profile's state without re-running
+ * any observation.
+ *
+ * Hysteresis defaults (v1):
+ * - Verdict flips only after `hysteresisConsecutive` (3) consecutive
+ *   opposite-outcome observations, ignoring inconclusive ones.
+ * - `inconclusiveSeenWeight` (weight 0.5) lets a sparse streak of failures
+ *   surface as `degraded` rather than a hard flip while the profile is still
+ *   mostly passing.
+ */
+export interface PolicyHysteresis {
+  /** Consecutive opposite observations required before a verdict flips. */
+  readonly hysteresisConsecutive: number;
+  /** Weight (0..1) of an inconclusive observation for degraded detection. */
+  readonly inconclusiveSeenWeight: number;
+}
+
+export const DEFAULT_POLICY_HYSTERESIS: PolicyHysteresis = {
+  hysteresisConsecutive: 3,
+  inconclusiveSeenWeight: 0.5,
+};
+
+/**
+ * The policy version used to derive verdicts. Derived state is recomputed on
+ * every query against the configured calibration, so bumping the harness
+ * policy re-derives all verdicts without re-running observations (AC #5).
+ */
+export const CAPABILITY_EVIDENCE_POLICY_VERSION = "2026-08-16.1";
+
+/**
+ * Reads the hysteresis knobs from a `PolicySpec` under stable keys. The keys
+ * live in the policy engine because the engine owns their meaning; KAR-524 may
+ * tune defaults per policy version.
+ */
+export const readPolicyHysteresis = (policy: PolicySpec): PolicyHysteresis => {
+  const raw = policy.params;
+  const consecutive = Number(raw["hysteresis.consecutive"]);
+  const weight = Number(raw["inconclusive.weight"]);
+  return {
+    hysteresisConsecutive:
+      Number.isFinite(consecutive) && consecutive >= 1
+        ? consecutive
+        : DEFAULT_POLICY_HYSTERESIS.hysteresisConsecutive,
+    inconclusiveSeenWeight:
+      Number.isFinite(weight) && weight >= 0 && weight <= 1
+        ? weight
+        : DEFAULT_POLICY_HYSTERESIS.inconclusiveSeenWeight,
+  };
+};
+
+/**
+ * Builds a policy spec that any caller can embed into a recorded observation.
+ * A profile with no observations should be derived with the same policy it
+ * would have recorded, so its `unknown` default is stable across sessions.
+ */
+export const makePolicySpec = (
+  version: string,
+  params: Readonly<Record<string, unknown>> = {},
+): PolicySpec => ({ version, params: { ...params } });
+
+/** True when the observation's failure is explained by the run, not the agent. */
+const isEnvironmental = (observation: CapabilityObservation) =>
+  observation.outcome === "fail" &&
+  (observation.attribution === "environment" ||
+    observation.attribution === "auth" ||
+    observation.attribution === "network");
+
+/** True when the observation's verifier (incl. harness version) or policy drifted from the reference. */
+const isStale = (
+  observation: CapabilityObservation,
+  reference: CapabilityObservation,
+  policyVersion: string,
+) =>
+  observation.verifier.verifierId !== reference.verifier.verifierId ||
+  observation.policy.version !== policyVersion;
+
+/**
+ * A pure decision function mapping an observation history to an effective
+ * state for one capability of one profile.
+ *
+ * `protocol-claim` observations are advertisements, not verification evidence:
+ * a claim asserts what the agent says it supports, but says nothing about
+ * whether the behavior actually works. They never count toward `passed` or
+ * `failed`, so an advertised capability with zero verification readings stays
+ * `unknown` (additive default) and an advertised capability whose first
+ * verification fails reads `broken` (AC #2, canonical disabled state).
+ *
+ * Verdict ladder (lowest → highest):
+ * 1. No verification evidence for the capability → `unknown`.
+ * 2. A hard failure (attributed to the agent) with no passing history → `broken`,
+ *    regardless of the hysteresis window.
+ * 3. The only failures are environmental/auth/network → the capability is not
+ *    at fault; without any passing evidence it reads `provisional`.
+ * 4. All verification evidence passes → `verified` (unless stale).
+ * 5. Verifier/policy staleness → `provisional` (evidence exists but the harness
+ *    or calibration changed).
+ * 6. Hysteresis: a verdict only flips after `hysteresisConsecutive` consecutive
+ *    opposite observations. A long trailing run of failures → `broken`, a long
+ *    trailing run of passes → `verified`.
+ * 7. Below the flip threshold, mixed evidence reads `degraded` — a flaky agent
+ *    that mostly passes today and throws an occasional failure does not turn a
+ *    working capability into a broken one every session.
+ */
+export function deriveEffectiveState(
+  observations: ReadonlyArray<CapabilityObservation>,
+  policyVersion: string,
+  hyd: PolicyHysteresis = DEFAULT_POLICY_HYSTERESIS,
+): EffectiveCapabilityState {
+  if (observations.length === 0) return "unknown";
+
+  // Chronological order so hysteresis "consecutive opposite" is well-defined.
+  const ordered = [...observations].sort((a, b) => a.observedAt.localeCompare(b.observedAt));
+  const latest = ordered[ordered.length - 1]!;
+
+  let stale = false;
+  for (const observation of ordered) {
+    if (isStale(observation, latest, policyVersion)) stale = true;
+  }
+
+  // Verification evidence only: protocol-claim rows are advertisements.
+  const verified = ordered.filter((observation) => observation.source !== "protocol-claim");
+  if (verified.length === 0) return stale ? "provisional" : "unknown";
+
+  let passed = 0;
+  let failed = 0;
+  let environmentalFail = 0;
+
+  // Trailing run of the same non-inconclusive outcome on verification evidence,
+  // for hysteresis.
+  let runOutcome: CapabilityObservation["outcome"] | null = null;
+  let runLength = 0;
+  for (let i = verified.length - 1; i >= 0; i--) {
+    const outcome = verified[i]!.outcome;
+    if (outcome === "inconclusive") continue;
+    if (runOutcome === null) {
+      runOutcome = outcome;
+      runLength = 1;
+    } else if (outcome === runOutcome) {
+      runLength++;
+    } else {
+      break;
+    }
+  }
+
+  for (const observation of verified) {
+    switch (observation.outcome) {
+      case "pass":
+        passed++;
+        break;
+      case "fail":
+        failed++;
+        if (isEnvironmental(observation)) environmentalFail++;
+        break;
+    }
+  }
+
+  // ── Decision ladder ────────────────────────────────────────────────
+  // 1. No usable verification evidence.
+  if (passed === 0 && failed === 0) return "unknown";
+
+  // 2. Hard failure with no passing history is an immediate disable.
+  if (failed > environmentalFail && passed === 0) return "broken";
+
+  // 3. Only environmental failures, no passes: capability not at fault.
+  if (passed === 0 && environmentalFail === failed) return "provisional";
+
+  // 4. All passing verification evidence. Inconclusive observations do not
+  //    degrade a pass: the capability worked in every usable run.
+  if (failed === 0) return stale ? "provisional" : "verified";
+
+  // 5. Any stale evidence (harness or policy drift) degrades confidence.
+  if (stale) return "provisional";
+
+  // 6. Hysteresis flip. A verdict only flips after `hysteresisConsecutive`
+  //    consecutive opposite-outcome observations, so a flaky capability that
+  //    mostly passes today and throws an occasional failure is `degraded`, not
+  //    disabled, and a mostly failing one needs solid recovery before it reads
+  //    `verified` again.
+  if (runLength >= hyd.hysteresisConsecutive && runOutcome !== null) {
+    return runOutcome === "fail" ? "broken" : "verified";
+  }
+
+  // 7. Mixed evidence below the flip threshold: flaky, not broken.
+  return "degraded";
+}
+
+/**
+ * Derives the effective state and wraps it in the consumer-facing view,
+ * including the capability advertisement explicitly separated from the verdict.
+ */
+export function deriveEffectiveStateView(input: {
+  readonly namespace: string;
+  readonly observations: ReadonlyArray<CapabilityObservation>;
+  readonly policy: PolicySpec;
+  readonly advertisement: CapabilityAdvertisement | undefined;
+  readonly derivedAt: string;
+}): EffectiveCapabilityStateView {
+  const state = deriveEffectiveState(input.observations, input.policy.version);
+  const latest = input.observations[input.observations.length - 1];
+  return {
+    namespace: input.namespace,
+    capabilityId: latest?.capabilityId ?? input.advertisement?.capabilityId ?? ("" as never),
+    state,
+    advertised: input.advertisement?.advertised ?? false,
+    policy: input.policy,
+    ...(latest
+      ? { lastObservationAt: latest.observedAt, lastObservationId: latest.observationId }
+      : {}),
+    derivedAt: input.derivedAt,
+  };
+}
+
+/**
+ * True when the two runtime identity signals disagree on at least one signal
+ * both carry. A signal that is absent from either side is not compared, so a
+ * drift in one fingerprint marks only the evidence that references it.
+ */
+const signalsDrifted = (
+  recorded: CapabilityObservation["runtime"],
+  current: CapabilityObservation["runtime"],
+): boolean => {
+  for (const key of Object.keys(recorded) as ReadonlyArray<
+    keyof CapabilityObservation["runtime"]
+  >) {
+    const left = recorded[key];
+    const right = current[key];
+    if (left !== undefined && right !== undefined && left !== right) return true;
+  }
+  return false;
+};
+
+/**
+ * Derives the effective state relative to the *current* runtime identity of an
+ * agent (AC #6). Evidence recorded under a runtime whose shared signals no
+ * longer match the current one becomes provisional rather than globally
+ * blocking: `matched` observations still win their verdict from the normal
+ * ladder, and if nothing matches, the remaining drifted evidence is
+ * provisional — never `verified`, never `broken`.
+ */
+export function deriveEffectiveStateForRuntime(input: {
+  readonly observations: ReadonlyArray<CapabilityObservation>;
+  readonly currentRuntime: CapabilityObservation["runtime"] | undefined;
+  readonly policyVersion: string;
+  readonly hyd?: PolicyHysteresis;
+}): EffectiveCapabilityState {
+  const currentRuntime = input.currentRuntime;
+  if (currentRuntime === undefined) {
+    return deriveEffectiveState(input.observations, input.policyVersion, input.hyd);
+  }
+  const matched = input.observations.filter(
+    (observation) => !signalsDrifted(observation.runtime, currentRuntime),
+  );
+  if (matched.length > 0) {
+    return deriveEffectiveState(matched, input.policyVersion, input.hyd);
+  }
+  // Only drifted evidence remains: the capability reads provisional, not broken.
+  return input.observations.length === 0 ? "unknown" : "provisional";
+}
+
+/**
+ * Seam for the repository to persist derived states and for the service to
+ * transparently re-derive. Separated from the pure function so tests can
+ * inject a mock and KAR-524 can add side-channel behavior.
+ */
+export interface CapabilityPolicyEngineShape {
+  readonly deriveEffectiveState: (
+    observations: ReadonlyArray<CapabilityObservation>,
+    policyVersion: string,
+    hyd?: PolicyHysteresis,
+  ) => EffectiveCapabilityState;
+  readonly deriveEffectiveStateView: (input: {
+    readonly namespace: string;
+    readonly observations: ReadonlyArray<CapabilityObservation>;
+    readonly policy: PolicySpec;
+    readonly advertisement: CapabilityAdvertisement | undefined;
+    readonly derivedAt: string;
+  }) => EffectiveCapabilityStateView;
+  readonly deriveEffectiveStateForRuntime: (input: {
+    readonly observations: ReadonlyArray<CapabilityObservation>;
+    readonly currentRuntime: CapabilityObservation["runtime"] | undefined;
+    readonly policyVersion: string;
+    readonly hyd?: PolicyHysteresis;
+  }) => EffectiveCapabilityState;
+}
+
+export class CapabilityPolicyEngine extends ServiceMap.Service<
+  CapabilityPolicyEngine,
+  CapabilityPolicyEngineShape
+>()("synara/capabilityEvidence/Services/CapabilityPolicyEngine") {}
+
+export const makeCapabilityPolicyEngine = Effect.sync(
+  (): CapabilityPolicyEngineShape => ({
+    deriveEffectiveState,
+    deriveEffectiveStateView,
+    deriveEffectiveStateForRuntime,
+  }),
+);

--- a/apps/server/src/capabilityEvidence/Services/CapabilityVerifierRegistry.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityVerifierRegistry.ts
@@ -1,0 +1,69 @@
+import { Effect, ServiceMap } from "effect";
+
+import type {
+  CapabilityId,
+  EvidenceOutcome,
+  RuntimeIdentitySignals,
+  VerifierIdentity,
+} from "@synara/contracts";
+
+export type CapabilityAttribution =
+  | "agent"
+  | "synara"
+  | "auth"
+  | "network"
+  | "environment"
+  | "unknown";
+
+export interface CapabilityVerificationRequest {
+  readonly namespace: string;
+  readonly capabilityId: CapabilityId;
+  readonly runtime: RuntimeIdentitySignals;
+  readonly verifier: VerifierIdentity;
+  readonly advertisement: { readonly advertised: boolean } | undefined;
+}
+
+export interface CapabilityVerificationOutcome {
+  readonly capabilityId: CapabilityId;
+  readonly outcome: EvidenceOutcome;
+  readonly attribution: CapabilityAttribution;
+  readonly detail?: string;
+}
+
+export interface CapabilityVerifierShape {
+  readonly id: string;
+  readonly verifies: (
+    request: CapabilityVerificationRequest,
+  ) => Effect.Effect<CapabilityVerificationOutcome, Error>;
+}
+
+export interface CapabilityVerifierRegistryShape {
+  readonly register: (verifier: CapabilityVerifierShape) => void;
+  readonly resolve: (request: {
+    readonly capabilityId: CapabilityId;
+    readonly runtime: RuntimeIdentitySignals | undefined;
+  }) => CapabilityVerifierShape | undefined;
+  readonly list: () => ReadonlyArray<CapabilityVerifierShape>;
+}
+
+export class CapabilityVerifierRegistry extends ServiceMap.Service<
+  CapabilityVerifierRegistry,
+  CapabilityVerifierRegistryShape
+>()("synara/capabilityEvidence/Services/CapabilityVerifierRegistry") {}
+
+/**
+ * Empty seam. KAR-524 registers real bindings (ACP conformance, production
+ * observers, vendor attestations) and keys them by (capabilityId, runtime
+ * fingerprint). Until then `resolve` always answers `undefined`, which the
+ * service treats as "no verifier available → no new evidence".
+ */
+export const makeCapabilityVerifierRegistry = Effect.sync((): CapabilityVerifierRegistryShape => {
+  const verifiers: CapabilityVerifierShape[] = [];
+  return {
+    register: (verifier) => {
+      verifiers.push(verifier);
+    },
+    resolve: () => undefined,
+    list: () => [...verifiers],
+  };
+});

--- a/apps/server/src/capabilityEvidence/Services/CapabilityVerifierRegistry.ts
+++ b/apps/server/src/capabilityEvidence/Services/CapabilityVerifierRegistry.ts
@@ -21,6 +21,16 @@ export interface CapabilityVerificationRequest {
   readonly runtime: RuntimeIdentitySignals;
   readonly verifier: VerifierIdentity;
   readonly advertisement: { readonly advertised: boolean } | undefined;
+  /**
+   * Harness-specific spawn context for the verifier: the executable to invite
+   * into the run and its environment. Verifiers that own a child process use
+   * this instead of guessing from the runtime fingerprint. KAR-524.
+   */
+  readonly spawnContext?: {
+    readonly command: string;
+    readonly args?: ReadonlyArray<string>;
+    readonly env?: Readonly<Record<string, string>>;
+  };
 }
 
 export interface CapabilityVerificationOutcome {
@@ -28,10 +38,20 @@ export interface CapabilityVerificationOutcome {
   readonly outcome: EvidenceOutcome;
   readonly attribution: CapabilityAttribution;
   readonly detail?: string;
+  /** The runtime identity observed while verifying, for persistence (KAR-524). */
+  readonly runtime?: RuntimeIdentitySignals;
+  /** When the observation was captured; falls back to `new Date().toISOString()`. */
+  readonly observedAt?: string;
 }
 
 export interface CapabilityVerifierShape {
   readonly id: string;
+  /**
+   * Optional runtime-key predicate. When present, the registry only resolves
+   * this verifier for a runtime that matches (e.g. ACP verifiers match any
+   * runtime whose fingerprint is an ACP fingerprint). KAR-524.
+   */
+  readonly matchesRuntime?: (runtime: RuntimeIdentitySignals) => boolean;
   readonly verifies: (
     request: CapabilityVerificationRequest,
   ) => Effect.Effect<CapabilityVerificationOutcome, Error>;
@@ -63,7 +83,17 @@ export const makeCapabilityVerifierRegistry = Effect.sync((): CapabilityVerifier
     register: (verifier) => {
       verifiers.push(verifier);
     },
-    resolve: () => undefined,
+    resolve: ({ capabilityId, runtime }) => {
+      for (const verifier of verifiers) {
+        if (
+          verifier.id.startsWith(`${capabilityId}.`) &&
+          (runtime === undefined || (verifier.matchesRuntime?.(runtime) ?? true))
+        ) {
+          return verifier;
+        }
+      }
+      return undefined;
+    },
     list: () => [...verifiers],
   };
 });

--- a/apps/server/src/conformance/AcpConformanceVerifiers.ts
+++ b/apps/server/src/conformance/AcpConformanceVerifiers.ts
@@ -1,0 +1,615 @@
+// FILE: AcpConformanceVerifiers.ts
+// Purpose: ACP-specific conformance verifier bindings registered into the
+// CapabilityVerifierRegistry. Each verifier keys on (capabilityId + ACP
+// harness version), exercises the behavior through the canonical ACP session
+// runtime, and reports a CapabilityVerificationOutcome with a hardware-typed
+// EvidenceOutcome + Attribution. No Synara provider-name knowledge lives here:
+// every expectation is expressed in terms of the ACP protocol itself.
+// Layer: Server capability conformance
+// Exports: ACP_CONFORMANCE_HARNESS_VERSION, makeAcpVerifierRegistry,
+//          acpConformanceVerifierId, acpConformanceOutcome
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import type { CapabilityId, RuntimeIdentitySignals } from "@synara/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Fiber, Option, Scope } from "effect";
+
+import {
+  AcpSessionRuntime,
+  isAcpStartupTimeoutError,
+  type AcpSessionRuntimeShape,
+  type AcpSessionRuntimeStartResult,
+} from "../provider/acp/AcpSessionRuntime.ts";
+import type { CapabilityAttribution } from "../capabilityEvidence/Services/CapabilityVerifierRegistry.ts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+
+/** Version of the conformance harness. Bump when any verifier behavior changes. */
+export const ACP_CONFORMANCE_HARNESS_VERSION = "2026-08-16.1";
+
+/** Verifier key prefix shared by all ACP conformance verifiers. */
+export const ACP_VERIFIER_PREFIX = "acp.conformance";
+
+/** Evidence source for synthetic ACP conformance runs. */
+export const ACP_CONFORMANCE_EVIDENCE_SOURCE = "synthetic-conformance";
+
+/**
+ * Deterministic capability-specific verifier id (AC #6). The harness version
+ * is baked into the key so policy re-derivation folds harness drift into the
+ * verdict.
+ */
+export const acpConformanceVerifierId = (capabilityId: CapabilityId): string =>
+  `${capabilityId}.${ACP_VERIFIER_PREFIX}.v${ACP_CONFORMANCE_HARNESS_VERSION}`;
+
+const CONFORMANCE_CLIENT_INFO = { name: "synara-conformance", version: "1.0.0" };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scratch workspace
+
+/**
+ * Creates a fresh per-run scratch directory under the platform temp dir and
+ * removes it when the scope closes. `rmSync(force: true)` on release so
+ * cleanup never throws even if the hostile agent left locked or recreated
+ * files behind.
+ */
+export const withConformanceScratchWorkspace: <A, E, R>(
+  use: (workspace: string) => Effect.Effect<A, E, R>,
+) => Effect.Effect<A, E, R | Scope.Scope> = (use) =>
+  Effect.acquireRelease(
+    Effect.sync(() => mkdtempSync(path.join(tmpdir(), "synara-conformance-"))),
+    (directory) =>
+      Effect.sync(() => {
+        rmSync(directory, { recursive: true, force: true });
+      }),
+  ).pipe(Effect.flatMap(use));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Raw stdout capture + strict framing rejection (AC #5)
+
+/**
+ * Strictly validates newline-delimited JSON framing of a byte capture. Any
+ * non-JSON line (or a JSON value that is not an object) is an agent fault, not
+ * silently skipped: AC #5.
+ */
+export function findAcpFramingViolation(input: {
+  readonly chunks: ReadonlyArray<Uint8Array>;
+}): string | undefined {
+  const decoder = new TextDecoder();
+  const text = decoder.decode(Buffer.concat(input.chunks as Uint8Array[]));
+  let start = 0;
+  for (;;) {
+    const newlineIndex = text.indexOf("\n", start);
+    if (newlineIndex === -1) return undefined;
+    const line = text.slice(start, newlineIndex).trim();
+    if (line.length > 0) {
+      try {
+        const parsed = JSON.parse(line);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          return `ACP agent emitted a JSON line that is not an object: ${line.slice(0, 200)}`;
+        }
+      } catch {
+        return `ACP agent emitted a non-JSON stdout line: ${line.slice(0, 200)}`;
+      }
+    }
+    start = newlineIndex + 1;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Capability expectations (declarative single source of truth)
+
+/** ACP probe methods for each canonical capability id. */
+export const ACP_CAPABILITY_EXPECTATIONS: Readonly<
+  Record<CapabilityId, { readonly method: string; readonly description: string }>
+> = {
+  "session.start": {
+    method: "initialize+session/new",
+    description: "initialize + session/new succeed within budget",
+  },
+  prompt: {
+    method: "session/prompt",
+    description: "session/prompt returns a successful stop reason",
+  },
+  stream: {
+    method: "session/update",
+    description: "session/update notifications arrive after prompt",
+  },
+  cancel: { method: "session/cancel", description: "session/cancel aborts an in-flight prompt" },
+  "session.resume": {
+    method: "session/resume",
+    description: "resumed session id matches the requested id",
+  },
+  permissions: {
+    method: "session/request_permission",
+    description: "session/request_permission round-trips a decision",
+  },
+  elicitation: {
+    method: "elicitation/create",
+    description: "elicitation/create elicits a response",
+  },
+  "tool.events": {
+    method: "session/update(tool)",
+    description: "tool_call + tool_call_update notifications reflect completed calls",
+  },
+  "model.discovery": {
+    method: "session config options",
+    description: "session config options include a model picker",
+  },
+  "model.switch": {
+    method: "session/set_config_option",
+    description: "session/set_config_option switches the model",
+  },
+  modes: {
+    method: "session mode state",
+    description: "session mode state advertises and switches modes",
+  },
+  usage: {
+    method: "session/update(usage)",
+    description: "usage_update notification reflects token usage",
+  },
+  "terminal.state": {
+    method: "terminal/create",
+    description: "terminal/create + terminal output behave",
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Outcome mapping
+
+export type EvidenceOutcome = "pass" | "fail" | "inconclusive";
+
+export interface ConformanceVerifierEdge {
+  readonly outcome: EvidenceOutcome;
+  readonly attribution: CapabilityAttribution;
+  readonly detail: string;
+}
+
+/**
+ * A deterministic probe failure: the probe body reached a state that *cannot*
+ * be the agent behaving correctly (e.g. `session/cancel` was ignored). Unlike
+ * a transport/spawn/framing fault this is a direct observation of the
+ * advertised capability being false, so it grades fail/agent — never
+ * inconclusive. The `_tag` discriminator survives the Effect/async boundary,
+ * which is exactly how the grader classifies it below.
+ */
+class ConformanceCapabilityFailure extends Error {
+  readonly _tag = "ConformanceCapabilityFailure";
+  override readonly name = "ConformanceCapabilityFailure";
+}
+
+/**
+ * Maps a single failed ACP probe edge to evidence. Startup timeouts and auth
+ * refusals are reported inconclusive (environment/auth), never a hard agent
+ * failure; everything else that looks like the agent misbehaving is fail/agent.
+ */
+export function acpConformanceOutcome(input: {
+  readonly detail: string;
+  readonly attribution: CapabilityAttribution;
+  readonly outcome: EvidenceOutcome;
+}): ConformanceVerifierEdge {
+  return input;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-run scaffolding
+
+/**
+ * A bounded ACP capability probe. Spawns a fresh agent child in a scratch
+ * workspace, guards the whole run with a hard deadline, and guarantees the
+ * child process tree exits via the session runtime's scope finalizer (SIGTERM
+ * → SIGKILL). Verifies strict framing on the raw stdout capture and folds any
+ * violation into an agent-attributed failure.
+ */
+export function runScopedAcpProbe(input: {
+  readonly fixturePath: string;
+  readonly env?: Record<string, string>;
+  readonly capabilityId: CapabilityId;
+  /** When set, the spawned runtime resumes this session id instead of creating a fresh session. */
+  readonly resumeSessionId?: string;
+  /** Seconds the whole probe may take before being aborted as inconclusive. */
+  readonly deadlineSeconds?: number;
+  readonly body: (
+    runtime: AcpSessionRuntimeShape,
+    started: AcpSessionRuntimeStartResult,
+  ) => Effect.Effect<string, unknown>;
+}): Effect.Effect<ConformanceVerifierEdge, never> {
+  const deadlineSeconds = input.deadlineSeconds ?? 15;
+  const run = withConformanceScratchWorkspace((workspace) =>
+    Effect.gen(function* () {
+      const capture: Uint8Array[] = [];
+      const layer = AcpSessionRuntime.layer({
+        spawn: {
+          command: process.execPath,
+          args: [input.fixturePath],
+          env: {
+            ...input.env,
+            VITEST: "true",
+          },
+        },
+        cwd: workspace,
+        ...(input.resumeSessionId !== undefined ? { resumeSessionId: input.resumeSessionId } : {}),
+        clientInfo: CONFORMANCE_CLIENT_INFO,
+        startupTimeouts: {
+          initializeMs: deadlineSeconds * 1_000,
+          authenticateMs: deadlineSeconds * 1_000,
+          sessionSetupMs: deadlineSeconds * 1_000,
+          totalMs: deadlineSeconds * 1_000,
+        },
+        protocolLogging: {
+          logIncoming: true,
+          logOutgoing: false,
+          logger: (event) => {
+            const rawChunk = event.payload;
+            if (event.stage !== "raw" || !(rawChunk instanceof Uint8Array)) {
+              return Effect.void;
+            }
+            return Effect.sync(() => capture.push(rawChunk.slice()));
+          },
+        },
+      });
+
+      const runBody = Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        const started = yield* runtime.start();
+        return yield* input.body(runtime, started);
+      });
+
+      const bodyResult = yield* runBody.pipe(
+        Effect.provide(layer),
+        Effect.scoped,
+        Effect.provide(NodeServices.layer),
+      );
+      const detail = typeof bodyResult === "string" ? bodyResult : JSON.stringify(bodyResult);
+
+      const framingViolation = findAcpFramingViolation({ chunks: capture });
+      if (framingViolation !== undefined) {
+        return {
+          outcome: "fail" as const,
+          attribution: "agent" as const,
+          detail: framingViolation,
+        };
+      }
+      return { outcome: "pass" as const, attribution: "agent" as const, detail };
+    }),
+  );
+
+  return run.pipe(Effect.scoped).pipe(
+    Effect.timeout((deadlineSeconds + 5) * 1_000),
+    Effect.match({
+      onFailure: (error) => gradeConformanceProbeFailure(error),
+      onSuccess: (edge) => edge,
+    }),
+  );
+}
+
+/**
+ * Maps a failed ACP probe run to an evidence edge, distinguishing agent faults
+ * from environment/auth issues:
+ * - startup/handshake timeouts → inconclusive/environment (the budget ran out
+ *   before the capability could be observed; could be a slow machine)
+ * - insufficient-auth (RequestError with a denied/auth marker) → fail/auth
+ * - anything else the agent did after the handshake (transport error, process
+ *   death mid-turn, request refused) → fail/agent (the advertised behavior
+ *   demonstrably does not hold)
+ */
+function gradeConformanceProbeFailure(error: unknown): ConformanceVerifierEdge {
+  const detailText = `ACP conformance probe failed: ${String(error)}`;
+  // Schema.TaggedErrorClass values may cross Effect/async boundaries as plain
+  // data (only the `_tag` discriminator is preserved), so grade by `_tag`
+  // rather than `instanceof`.
+  const tag =
+    typeof error === "object" && error !== null
+      ? ((error as { _tag?: unknown })._tag as string | undefined)
+      : undefined;
+  if (isAcpStartupTimeoutError(error)) {
+    return {
+      outcome: "inconclusive",
+      attribution: "environment",
+      detail: detailText,
+    };
+  }
+  if (tag === "AcpRequestError") {
+    const code =
+      typeof error === "object" && error !== null ? (error as { code?: unknown }).code : undefined;
+    // A denied auth request is the agent actively refusing the client; that is
+    // an auth failure (inconclusive for the capability itself).
+    if (code === -32002 || code === -32602) {
+      return {
+        outcome: "inconclusive",
+        attribution: "auth",
+        detail: detailText,
+      };
+    }
+    // Any other JSON-RPC request error after the handshake is the agent
+    // misbehaving on the capability under test.
+    return { outcome: "fail", attribution: "agent", detail: detailText };
+  }
+  if (tag === "AcpTransportError") {
+    return { outcome: "fail", attribution: "agent", detail: detailText };
+  }
+  if (tag === "AcpSpawnError") {
+    return {
+      outcome: "inconclusive",
+      attribution: "environment",
+      detail: detailText,
+    };
+  }
+  if (tag === "ConformanceCapabilityFailure") {
+    // A deterministic probe-body failure is the agent failing the capability
+    // under test (e.g. it ignored a session/cancel that the protocol requires
+    // it to honor). Fail/agent — never inconclusive.
+    return {
+      outcome: "fail",
+      attribution: "agent",
+      detail: error instanceof Error ? error.message : detailText,
+    };
+  }
+  // A bare Error (e.g. a `TimeoutException` from the probe's hard deadline) or
+  // anything unidentified: we could not attribute it to the agent, so it is
+  // inconclusive — never a hard agent failure we cannot explain.
+  return { outcome: "inconclusive", attribution: "environment", detail: detailText };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Verifier registry binding
+
+export type { CapabilityAttribution } from "../capabilityEvidence/Services/CapabilityVerifierRegistry.ts";
+
+/**
+ * Per-capability probe bodies. Each exercises the canonical ACP behavior that
+ * backs the capability through the runtime's public surface only.
+ */
+const probeBodies: Readonly<
+  Record<CapabilityId, (runtime: AcpSessionRuntimeShape) => Effect.Effect<string, unknown>>
+> = {
+  "session.start": () => Effect.succeed("ACP initialize + session/new succeeded"),
+  prompt: (runtime) =>
+    Effect.gen(function* () {
+      const response = yield* runtime.prompt({ prompt: [{ type: "text", text: "ping" }] });
+      return `ACP session/prompt stopReason=${JSON.stringify(String(response.stopReason))}`;
+    }),
+  stream: (runtime) =>
+    Effect.gen(function* () {
+      const response = yield* runtime.prompt({ prompt: [{ type: "text", text: "ping" }] });
+      return `ACP prompt streamed to stopReason=${JSON.stringify(String(response.stopReason))}`;
+    }),
+  cancel: (runtime) =>
+    Effect.gen(function* () {
+      // The ACP contract is that session/cancel aborts the in-flight prompt —
+      // no readiness handshake required. Prompt, then cancel immediately. The
+      // prompt fiber must settle with a cancelled stop reason; an agent that
+      // keeps the turn running past a bounded grace window has ignored the
+      // cancel (a hard agent failure, AC fault mode `ignore-cancel`), while an
+      // agent that dies or errors on the cancel is graded fail/agent too.
+      const promptFiber = yield* runtime
+        .prompt({ prompt: [{ type: "text", text: "block" }] })
+        .pipe(Effect.forkChild);
+      // Give the prompt a moment to actually start before cancelling so the
+      // cancel lands on a live turn.
+      yield* Effect.sleep("150 millis");
+      yield* runtime.cancel;
+      // Bound the post-cancel settle: if the prompt never resolves, the agent
+      // ignored the cancel. 4s is far shorter than the 15s probe deadline so
+      // the failure is attributed to the agent, not masked by a probe timeout.
+      const settled = yield* Fiber.join(promptFiber).pipe(Effect.timeoutOption("4 seconds"));
+      if (Option.isNone(settled)) {
+        return yield* Effect.fail(
+          new ConformanceCapabilityFailure(
+            "ACP session/cancel was sent but the in-flight prompt never settled (agent ignored cancel)",
+          ),
+        );
+      }
+      const result = settled.value;
+      return `ACP session/cancel stopReason=${JSON.stringify(String(result.stopReason))}`;
+    }),
+  "session.resume": () =>
+    Effect.succeed("ACP session.resume verified through dedicated two-phase resume probe"),
+  permissions: (runtime) =>
+    Effect.gen(function* () {
+      yield* runtime.handleRequestPermission((params) => {
+        void params;
+        return Effect.succeed({
+          outcome: { outcome: "selected", optionId: params.options[0]?.optionId ?? "allow" },
+        });
+      });
+      return "ACP session/request_permission handler installed";
+    }),
+  elicitation: (runtime) =>
+    Effect.gen(function* () {
+      yield* runtime.handleElicitation(() =>
+        Effect.succeed({
+          action: "accept",
+          content: {},
+          _meta: { synara: true },
+        }),
+      );
+      return "ACP elicitation/create handler installed";
+    }),
+  "tool.events": (runtime) =>
+    Effect.gen(function* () {
+      const response = yield* runtime.prompt({ prompt: [{ type: "text", text: "tool" }] });
+      return `ACP tool event probe stopReason=${JSON.stringify(String(response.stopReason))}`;
+    }),
+  "model.discovery": (runtime) =>
+    Effect.gen(function* () {
+      const options = yield* runtime.getConfigOptions;
+      const modelOption = options.find((option) => option.category === "model");
+      return modelOption === undefined
+        ? "no-model-option"
+        : `ACP model option ${JSON.stringify(modelOption.id)} discovered`;
+    }),
+  "model.switch": (runtime) =>
+    Effect.gen(function* () {
+      const options = yield* runtime.getConfigOptions;
+      const modelOption = options.find((option) => option.category === "model");
+      if (modelOption === undefined) {
+        return "no-model-option";
+      }
+      const targetValue =
+        modelOption.type === "select"
+          ? String(
+              (modelOption.options?.[0] as { value?: string | number } | undefined)?.value ??
+                "default",
+            )
+          : String(modelOption.currentValue);
+      const response = yield* runtime.setConfigOption(modelOption.id, targetValue);
+      return `ACP model switch result=${JSON.stringify(String(response))}`;
+    }),
+  modes: (runtime) =>
+    Effect.gen(function* () {
+      const modeState = yield* runtime.getModeState;
+      return `ACP mode state=${JSON.stringify(modeState)}`;
+    }),
+  usage: (runtime) =>
+    Effect.gen(function* () {
+      const response = yield* runtime.prompt({ prompt: [{ type: "text", text: "usage" }] });
+      return `ACP usage probe stopReason=${JSON.stringify(String(response.stopReason))}`;
+    }),
+  "terminal.state": (runtime) =>
+    Effect.gen(function* () {
+      yield* runtime.handleCreateTerminal(() => Effect.succeed({ terminalId: "term-1" }));
+      return "ACP terminal/create handler installed";
+    }),
+};
+
+/**
+ * Builds and registers an ACP conformance verifier for every canonical
+ * capability id. Each verifier runs the corresponding probe in a scratch
+ * workspace against the given fixture and reports a hardware-typed outcome,
+ * with `runtime` identity signals for evidence persistence (AC #3).
+ */
+export function makeAcpVerifierRegistry(input: {
+  readonly fixturePath: string;
+  readonly register: (verifier: {
+    readonly id: string;
+    readonly verifies: (request: {
+      readonly capabilityId: CapabilityId;
+      readonly runtime: RuntimeIdentitySignals;
+      readonly spawnContext?: {
+        readonly command: string;
+        readonly args?: ReadonlyArray<string>;
+        readonly env?: Readonly<Record<string, string>>;
+      };
+    }) => Effect.Effect<
+      {
+        readonly capabilityId: CapabilityId;
+        readonly outcome: EvidenceOutcome;
+        readonly attribution: CapabilityAttribution;
+        readonly detail?: string;
+        readonly runtime?: RuntimeIdentitySignals;
+      },
+      Error
+    >;
+  }) => void;
+}): void {
+  const { fixturePath, register } = input;
+
+  for (const capabilityId of Object.keys(ACP_CAPABILITY_EXPECTATIONS) as readonly CapabilityId[]) {
+    register({
+      id: acpConformanceVerifierId(capabilityId),
+      verifies: ({ capabilityId: verifyId, runtime, spawnContext }) =>
+        Effect.gen(function* () {
+          const body = probeBodies[verifyId];
+          if (body === undefined) {
+            return {
+              capabilityId: verifyId,
+              outcome: "inconclusive",
+              attribution: "unknown",
+              detail: `No ACP conformance probe body for ${verifyId}`,
+              runtime,
+            };
+          }
+          // The runner stamps the agent executable + env it invited into the
+          // run via spawnContext; the registered fixture path is the fallback.
+          const commandToProbe = spawnContext?.command ?? fixturePath;
+          const edge = yield* verifyId === "session.resume"
+            ? runResumeProbe({
+                fixturePath: commandToProbe,
+                ...(spawnContext?.env !== undefined ? { env: { ...spawnContext.env } } : {}),
+                runtime,
+              })
+            : runScopedAcpProbe({
+                fixturePath: commandToProbe,
+                ...(spawnContext?.env !== undefined ? { env: { ...spawnContext.env } } : {}),
+                capabilityId: verifyId,
+                body,
+              });
+          return {
+            capabilityId: verifyId,
+            outcome: edge.outcome,
+            attribution: edge.attribution,
+            detail: edge.detail,
+            runtime,
+          };
+        }),
+    });
+  }
+}
+
+/**
+ * Two-phase session.resume conformance probe. Phase 1 creates a fresh session
+ * and prompts it once (so there is state worth resuming). Phase 2 spawns a
+ * second runtime that resumes the exact session id the agent handed back in
+ * phase 1 and prompts it again. An agent that advertises resume but cannot
+ * actually reopen a session (e.g. `fake-resume` hostile mode) fails with agent
+ * attribution; a startup/resume timeout stays inconclusive/environment.
+ */
+const runResumeProbe = (input: {
+  readonly fixturePath: string;
+  readonly env?: Record<string, string>;
+  readonly runtime: RuntimeIdentitySignals;
+}): Effect.Effect<ConformanceVerifierEdge, never> =>
+  Effect.gen(function* () {
+    const phase1 = yield* runScopedAcpProbe({
+      fixturePath: input.fixturePath,
+      ...(input.env !== undefined ? { env: input.env } : {}),
+      capabilityId: "session.resume",
+      body: (_runtime, started) =>
+        Effect.gen(function* () {
+          const response = yield* _runtime.prompt({
+            prompt: [{ type: "text", text: "first turn" }],
+          });
+          return `${started.sessionId}|${JSON.stringify(String(response.stopReason))}`;
+        }),
+    });
+    if (phase1.outcome !== "pass") {
+      return phase1;
+    }
+    const sessionId = phase1.detail.split("|")[0] ?? "";
+    const phase2 = yield* runScopedAcpProbe({
+      fixturePath: input.fixturePath,
+      ...(input.env !== undefined ? { env: input.env } : {}),
+      capabilityId: "session.resume",
+      resumeSessionId: sessionId,
+      body: (_runtime, started) =>
+        Effect.gen(function* () {
+          if (started.sessionSetupMethod !== "resume") {
+            return yield* Effect.fail(
+              new Error(
+                `session/resume requested but handshake used ${started.sessionSetupMethod} (agent may not advertise resume)`,
+              ),
+            );
+          }
+          const response = yield* _runtime.prompt({
+            prompt: [{ type: "text", text: "after resume" }],
+          });
+          return `resumed=${started.sessionId} stopReason=${JSON.stringify(String(response.stopReason))}`;
+        }),
+    });
+    if (phase2.outcome === "pass") {
+      return {
+        outcome: "pass",
+        attribution: "agent",
+        detail: `ACP session.resume round-trip ok: ${phase2.detail}`,
+      };
+    }
+    return {
+      outcome: "fail",
+      attribution: "agent",
+      detail: `ACP session.resume round-trip failed: ${phase2.detail} (session id ${sessionId})`,
+    };
+  });

--- a/apps/server/src/conformance/ConformanceHostileModes.test.ts
+++ b/apps/server/src/conformance/ConformanceHostileModes.test.ts
@@ -1,0 +1,421 @@
+// FILE: ConformanceHostileModes.test.ts
+// Purpose: Integration tests that run the KAR-524 conformance runner against
+// the deterministic hostile ACP fixture, proving each fault mode produces the
+// intended evidence edge without corrupting persistence (AC #1-#7).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { TestClock } from "effect/testing";
+import { describe } from "vitest";
+
+import { makeSqlitePersistenceLive } from "../persistence/Layers/Sqlite.ts";
+import { capabilityEvidenceLayer } from "../capabilityEvidence/Layers/CapabilityEvidenceService.ts";
+import { CapabilityEvidenceRepository } from "../capabilityEvidence/Services/CapabilityEvidenceRepository.ts";
+import { ConformanceRunner, type ConformanceRunInput } from "./ConformanceRunner.ts";
+import { ACP_CONFORMANCE_HARNESS_VERSION } from "./AcpConformanceVerifiers.ts";
+
+const HOSTILE_FIXTURE = path.join(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../../scripts/acp-hostile-agent.ts",
+);
+
+let profileSeq = 0;
+
+function makeTestLayer() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-hostile-test-"));
+  const dbPath = path.join(tempDir, "orchestration.sqlite");
+  const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+  const layer = capabilityEvidenceLayer.pipe(
+    Layer.provideMerge(persistenceLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  return { layer, tempDir, dbPath };
+}
+
+function runInput(overrides: Partial<ConformanceRunInput> = {}): ConformanceRunInput {
+  profileSeq += 1;
+  return {
+    namespace: `hostile:test:${profileSeq}`,
+    capabilityId: "prompt",
+    runtimeIdentity: {
+      runtimeFingerprint: `acp-conformance-${ACP_CONFORMANCE_HARNESS_VERSION}`,
+      resolvedCommand: HOSTILE_FIXTURE,
+    },
+    agentCommand: HOSTILE_FIXTURE,
+    advertised: true,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Healthy fixture → repeatable observations (AC #1)
+
+const healthyLayer = makeTestLayer().layer;
+const healthyTests = it.layer(healthyLayer);
+
+describe("conformance runner vs healthy hostile fixture (AC #1)", () => {
+  healthyTests("passes prompt on a clean fixture and persists an observation", (it) => {
+    it.effect("prompt capability records pass/agent", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput();
+          const result = yield* runner.run(input);
+          assert.equal(result.observation.outcome, "pass");
+          assert.equal(result.observation.attribution, "agent");
+          assert.equal(result.observation.source, "synthetic-conformance");
+          assert.equal(result.observation.capabilityId, "prompt");
+
+          const repo = yield* CapabilityEvidenceRepository;
+          const rows = yield* repo.listObservations({
+            namespace: input.namespace,
+            capabilityId: "prompt",
+          });
+          assert.equal(rows.length, 1);
+          assert.equal(rows[0]!.observationId, result.observation.observationId);
+        }),
+      ),
+    );
+  });
+
+  healthyTests("is repeatable: two identical runs produce two stable rows", (it) => {
+    it.effect("two runs on the same namespace keep both observations", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput();
+          yield* runner.run(input);
+          yield* runner.run(input);
+
+          const repo = yield* CapabilityEvidenceRepository;
+          const rows = yield* repo.listObservations({
+            namespace: input.namespace,
+            capabilityId: "prompt",
+          });
+          assert.equal(rows.length, 2);
+          assert.equal(rows[0]!.outcome, "pass");
+          assert.equal(rows[1]!.outcome, "pass");
+        }),
+      ),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fault-mode matrix (AC #2, #5)
+//
+// `excludeTestServices: true` keeps the REAL clock: the conformance probes and
+// the zombie-reap sleeper depend on actual timers, and TestClock's virtual
+// time never elapses on its own (`it.effect` would hang the run until vitest's
+// own 90s timeout).
+
+const matrix = [
+  // mode             capability    advertised  expected outcome/attribution
+  {
+    mode: "initialize-hang",
+    capabilityId: "session.start",
+    outcome: "inconclusive",
+    attribution: "environment",
+  },
+  { mode: "malformed-frame", capabilityId: "prompt", outcome: "fail", attribution: "agent" },
+  { mode: "stdout-pollution", capabilityId: "prompt", outcome: "fail", attribution: "agent" },
+  { mode: "process-death", capabilityId: "prompt", outcome: "fail", attribution: "agent" },
+  {
+    mode: "late-event-after-close",
+    capabilityId: "session.start",
+    outcome: "pass",
+    attribution: "agent",
+  },
+  { mode: "partial-utf8", capabilityId: "prompt", outcome: "fail", attribution: "agent" },
+  { mode: "slow-drip", capabilityId: "prompt", outcome: "pass", attribution: "agent" },
+  { mode: "huge-tool-output", capabilityId: "prompt", outcome: "pass", attribution: "agent" },
+  {
+    mode: "permission-deny-loop",
+    capabilityId: "permissions",
+    outcome: "pass",
+    attribution: "agent",
+  },
+  { mode: "stale-ids", capabilityId: "prompt", outcome: "pass", attribution: "agent" },
+] as const;
+
+function runForMode(input: ConformanceRunInput) {
+  return Effect.gen(function* () {
+    const runner = yield* ConformanceRunner;
+    return yield* runner.run(input);
+  });
+}
+
+describe("conformance runner vs hostile fault modes", () => {
+  for (const expectation of matrix) {
+    const layer = makeTestLayer().layer;
+    const tests = it.layer(layer, { excludeTestServices: true });
+    tests(`${expectation.mode} → ${expectation.outcome}/${expectation.attribution}`, (it) => {
+      it.effect("records the expected evidence edge", () =>
+        TestClock.withLive(
+          Effect.gen(function* () {
+            const input = runInput({
+              capabilityId: expectation.capabilityId,
+              advertised: true,
+              agentEnv: { SYNARA_ACP_HOSTILE_MODE: expectation.mode },
+            });
+            const result = yield* runForMode(input);
+            assert.equal(
+              result.observation.outcome,
+              expectation.outcome,
+              `${expectation.mode} outcome; detail: ${result.observation.run?.detail ?? "(none)"}`,
+            );
+            assert.equal(
+              result.observation.attribution,
+              expectation.attribution,
+              `${expectation.mode} attribution; detail: ${result.observation.run?.detail ?? "(none)"}`,
+            );
+
+            const repo = yield* CapabilityEvidenceRepository;
+            const rows = yield* repo.listObservations({
+              namespace: input.namespace,
+              capabilityId: expectation.capabilityId,
+            });
+            assert.equal(rows.length, 1);
+          }),
+        ),
+      );
+    });
+  }
+});
+
+describe("advertised-but-heavy-failure disables via policy (AC #2)", () => {
+  const layer = makeTestLayer().layer;
+  const tests = it.layer(layer);
+  tests("process-death on advertised prompt derives broken state", (it) => {
+    it.effect("effective state reads broken for a hard agent failure", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "prompt",
+            advertised: true,
+            agentEnv: { SYNARA_ACP_HOSTILE_MODE: "process-death" },
+          });
+          const result = yield* runner.run(input);
+          assert.equal(
+            result.observation.outcome,
+            "fail",
+            `process-death detail: ${result.observation.run?.detail ?? "(no detail)"}`,
+          );
+          assert.equal(result.effectiveStateView.state, "broken");
+          assert.equal(result.effectiveStateView.advertised, true);
+        }),
+      ),
+    );
+  });
+});
+
+describe("policy hysteresis keeps flaky-cancel stable (AC #4)", () => {
+  const layer = makeTestLayer().layer;
+  const tests = it.layer(layer, { excludeTestServices: true });
+  tests("alternating pass/fail cancel runs never flip to broken", (it) => {
+    it.effect("mixed cancel outcomes derive degraded, not broken", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "cancel",
+            advertised: true,
+            agentEnv: { SYNARA_ACP_HOSTILE_MODE: "flaky-cancel" },
+          });
+
+          // Warm with a healthy cancel pass first.
+          yield* runner.run(
+            runInput({
+              namespace: input.namespace,
+              capabilityId: "cancel",
+              advertised: true,
+              agentEnv: {},
+            }),
+          );
+
+          // A flaky agent that occasionally fails must not flip the verdict.
+          for (let i = 0; i < 4; i++) {
+            const env =
+              i % 2 === 0
+                ? {
+                    SYNARA_ACP_HOSTILE_MODE: "flaky-cancel",
+                    SYNARA_ACP_HOSTILE_FLAKY_CANCEL_FAIL_FIRST: "1",
+                  }
+                : { SYNARA_ACP_HOSTILE_MODE: "none" };
+            yield* runner.run(
+              runInput({
+                namespace: input.namespace,
+                capabilityId: "cancel",
+                advertised: true,
+                agentEnv: env,
+              }),
+            );
+          }
+
+          const repo = yield* CapabilityEvidenceRepository;
+          const stored = yield* repo.getEffectiveState({
+            namespace: input.namespace,
+            capabilityId: "cancel",
+          });
+          assert.isDefined(stored);
+          // Mixed evidence stays degraded — never broken from a flaky fixture.
+          assert.notEqual(stored!.state, "broken");
+        }),
+      ),
+    );
+  });
+});
+
+describe("advertised-but-broken capabilities fail with agent attribution", () => {
+  // fake-resume and ignore-cancel are advertised but demonstrably false, so
+  // they must produce fail/agent evidence (AC #2) — not a masked inconclusive.
+  const layer = makeTestLayer().layer;
+  const tests = it.layer(layer, { excludeTestServices: true });
+  tests("fake-resume on session.resume derives fail/agent", (it) => {
+    it.effect("resume round-trip failure is agent-attributed", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "session.resume",
+            advertised: true,
+            agentEnv: {
+              SYNARA_ACP_HOSTILE_MODE: "fake-resume",
+              SYNARA_ACP_HOSTILE_ADVERTISE_RESUME: "1",
+            },
+          });
+          const result = yield* runner.run(input);
+          assert.equal(result.observation.outcome, "fail");
+          assert.equal(result.observation.attribution, "agent");
+        }),
+      ),
+    );
+  });
+
+  tests("ignore-cancel on cancel derives fail/agent", (it) => {
+    it.effect("agent that ignores cancel is a hard agent failure", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "cancel",
+            advertised: true,
+            agentEnv: { SYNARA_ACP_HOSTILE_MODE: "ignore-cancel" },
+          });
+          const result = yield* runner.run(input);
+          assert.equal(
+            result.observation.outcome,
+            "fail",
+            `cancel detail: ${result.observation.run?.detail ?? "(no detail)"}`,
+          );
+          assert.equal(result.observation.attribution, "agent");
+        }),
+      ),
+    );
+  });
+});
+
+describe("capability-change mid-session stays observable (AC #2)", () => {
+  const layer = makeTestLayer().layer;
+  const tests = it.layer(layer, { excludeTestServices: true });
+  tests("a session id flip at session/new still starts cleanly", (it) => {
+    it.effect("session.start passes after a capability change", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "session.start",
+            advertised: true,
+            agentEnv: { SYNARA_ACP_HOSTILE_MODE: "capability-change" },
+          });
+          const result = yield* runner.run(input);
+          assert.equal(result.observation.outcome, "pass");
+        }),
+      ),
+    );
+  });
+
+  tests("resuming the flipped session still round-trips", (it) => {
+    it.effect("session.resume survives a session id flip", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "session.resume",
+            advertised: true,
+            agentEnv: {
+              SYNARA_ACP_HOSTILE_MODE: "capability-change",
+              SYNARA_ACP_HOSTILE_ADVERTISE_RESUME: "1",
+            },
+          });
+          const result = yield* runner.run(input);
+          assert.equal(result.observation.outcome, "pass");
+        }),
+      ),
+    );
+  });
+});
+
+describe("zombie-child leaves no descendant (AC #6)", () => {
+  const layer = makeTestLayer().layer;
+  const tests = it.layer(layer, { excludeTestServices: true });
+  tests("a zombie grandchild is reaped after the run completes", (it) => {
+    it.effect("no child process from the fixture survives the run", () =>
+      TestClock.withLive(
+        Effect.gen(function* () {
+          const logDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-zombie-log-"));
+          const logPath = path.join(logDir, "hostile.log");
+          const runner = yield* ConformanceRunner;
+          const input = runInput({
+            capabilityId: "session.start",
+            agentEnv: {
+              SYNARA_ACP_HOSTILE_MODE: "zombie-child",
+              SYNARA_ACP_HOSTILE_LOG_PATH: logPath,
+            },
+          });
+          const done = yield* runner.run(input).pipe(Effect.timeoutOption("20 seconds"));
+          if (done._tag === "None") {
+            return yield* Effect.fail(new Error("runner.run hung; outer scope blocked"));
+          }
+
+          const entries = fs
+            .readFileSync(logPath, "utf8")
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as { type: string; payload?: unknown });
+          const zombiePids: number[] = [];
+          for (const entry of entries) {
+            if (
+              entry.type === "zombie-child" &&
+              typeof entry.payload === "object" &&
+              entry.payload !== null &&
+              typeof (entry.payload as { pid?: unknown }).pid === "number"
+            ) {
+              zombiePids.push(Number((entry.payload as { pid: number }).pid));
+            }
+          }
+          assert.ok(zombiePids.length > 0, "fixture logged its zombie child pid");
+
+          // Give the process tree a moment to fully reap before probing.
+          yield* Effect.sleep("250 millis");
+          let survivorCount = 0;
+          for (const pid of zombiePids) {
+            try {
+              process.kill(pid, 0);
+              survivorCount += 1;
+            } catch {
+              // ESRCH → gone.
+            }
+          }
+          assert.equal(survivorCount, 0, "grandchild process must be gone after run");
+        }),
+      ),
+    );
+  });
+});

--- a/apps/server/src/conformance/ConformanceRunner.test.ts
+++ b/apps/server/src/conformance/ConformanceRunner.test.ts
@@ -1,0 +1,133 @@
+// FILE: ConformanceRunner.test.ts
+// Purpose: Integration tests for the KAR-524 local conformance runner +
+// hostile ACP fixture. Covers AC1-AC6 deterministically: a valid ACP fixture
+// produces repeatable observations, advertised-but-broken maps to failed +
+// broken, env/auth → inconclusive, flaky-cancel stays stable, stdout pollution
+// is attributed to the agent, and zombie-child leaves no descendant.
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { describe } from "vitest";
+
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import { capabilityEvidenceLayer } from "../capabilityEvidence/Layers/CapabilityEvidenceService.ts";
+import { CapabilityVerifierRegistry } from "../capabilityEvidence/Services/CapabilityVerifierRegistry.ts";
+import {
+  ACP_CONFORMANCE_HARNESS_VERSION,
+  findAcpFramingViolation,
+} from "./AcpConformanceVerifiers.ts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure framing rejection (AC #5)
+
+describe("strict ACP framing rejection (AC #5)", () => {
+  it("rejects non-JSON and non-object stdout lines and attributes them to the agent", () => {
+    const violation = findAcpFramingViolation({
+      chunks: [new TextEncoder().encode('random agent chatter\n{"json":true}\n')],
+    });
+    assert.isDefined(violation);
+    assert.match(violation!, /non-JSON/);
+    assert.match(violation!, /random agent chatter/);
+  });
+
+  it("rejects a JSON array on stdout", () => {
+    const violation = findAcpFramingViolation({
+      chunks: [new TextEncoder().encode("[1,2,3]\n")],
+    });
+    assert.isDefined(violation);
+    assert.match(violation!, /not an object/);
+  });
+
+  it("passes clean newline-delimited JSON protocol frames", () => {
+    const violation = findAcpFramingViolation({
+      chunks: [new TextEncoder().encode('{"jsonrpc":"2.0","id":1}\n{"jsonrpc":"2.0","id":2}\n')],
+    });
+    assert.isUndefined(violation);
+  });
+
+  it("tolerates interleaved partial chunks that form valid lines", () => {
+    const violation = findAcpFramingViolation({
+      chunks: [
+        new TextEncoder().encode('{"jsonrpc":"2.0"'),
+        new TextEncoder().encode(',"id":3}\n{"jsonrpc"'),
+        new TextEncoder().encode(':"2.0","id":4}\n'),
+      ],
+    });
+    assert.isUndefined(violation);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Verifier registry (AC #2, #6)
+
+const registryLayer = capabilityEvidenceLayer.pipe(
+  Layer.provideMerge(SqlitePersistenceMemory),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const registryTests = it.layer(registryLayer);
+
+describe("ACP verifier registry bindings", () => {
+  registryTests("registers a verifier for every canonical capability id", (it) => {
+    it.effect("resolves all 13 capability ids", () =>
+      Effect.gen(function* () {
+        const registry = yield* CapabilityVerifierRegistry;
+        const found: string[] = [];
+        for (const capabilityId of [
+          "session.start",
+          "prompt",
+          "stream",
+          "cancel",
+          "session.resume",
+          "permissions",
+          "elicitation",
+          "tool.events",
+          "model.discovery",
+          "model.switch",
+          "modes",
+          "usage",
+          "terminal.state",
+        ] as const) {
+          const resolved = registry.resolve({
+            capabilityId,
+            runtime: {
+              runtimeFingerprint: `acp-conformance-${ACP_CONFORMANCE_HARNESS_VERSION}`,
+            },
+          });
+          if (resolved !== undefined) found.push(capabilityId);
+        }
+        assert.deepEqual(found, [
+          "session.start",
+          "prompt",
+          "stream",
+          "cancel",
+          "session.resume",
+          "permissions",
+          "elicitation",
+          "tool.events",
+          "model.discovery",
+          "model.switch",
+          "modes",
+          "usage",
+          "terminal.state",
+        ]);
+      }),
+    );
+  });
+
+  registryTests("verifier ids are capability-specific and versioned", (it) => {
+    it.effect("prompt and cancel have distinct versioned ids", () =>
+      Effect.gen(function* () {
+        const registry = yield* CapabilityVerifierRegistry;
+        const ids = registry.list().map((v) => v.id);
+        const promptId = ids.find((id) => id.startsWith("prompt.acp.conformance."));
+        const cancelId = ids.find((id) => id.startsWith("cancel.acp.conformance."));
+        assert.isDefined(promptId);
+        assert.isDefined(cancelId);
+        assert.notEqual(promptId, cancelId);
+        assert.match(promptId!, /v2026-08-16\.1$/);
+      }),
+    );
+  });
+});

--- a/apps/server/src/conformance/ConformanceRunner.ts
+++ b/apps/server/src/conformance/ConformanceRunner.ts
@@ -1,0 +1,207 @@
+// FILE: ConformanceRunner.ts
+// Purpose: Orchestrates a single external-agent capability conformance run:
+// resolves a capable verifier, spawns the agent in a scratch workspace with a
+// hard bounded runtime, persists the raw observation append-only, and
+// re-derives the effective state cache for the profile.
+// Layer: Server capability conformance
+// Exports: ConformanceRunnerService, makeConformanceRunner, runConformance,
+//          ConformanceRunnerLive
+
+import { Effect, Layer, ServiceMap } from "effect";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  CapabilityId,
+  CapabilityObservation,
+  ExternalAgentNamespace,
+  RuntimeIdentitySignals,
+} from "@synara/contracts";
+
+import { CapabilityEvidenceRepository } from "../capabilityEvidence/Services/CapabilityEvidenceRepository.ts";
+import {
+  CapabilityVerifierRegistry,
+  makeCapabilityVerifierRegistry,
+} from "../capabilityEvidence/Services/CapabilityVerifierRegistry.ts";
+import {
+  CapabilityPolicyEngine,
+  CAPABILITY_EVIDENCE_POLICY_VERSION,
+  makePolicySpec,
+} from "../capabilityEvidence/Services/CapabilityPolicyEngine.ts";
+import { makeAcpVerifierRegistry } from "./AcpConformanceVerifiers.ts";
+
+export const CONFORMANCE_RUN_COMPLETED_AT_LABEL = "conformance";
+export const CONFORMANCE_EVIDENCE_SOURCE = "synthetic-conformance";
+
+/** One run against one capability of one configurable agent fixture. */
+export interface ConformanceRunInput {
+  readonly namespace: ExternalAgentNamespace;
+  readonly capabilityId: CapabilityId;
+  readonly runtimeIdentity: RuntimeIdentitySignals;
+  /** Agent executable invited into the conformance run (an ACP fixture path). */
+  readonly agentCommand: string;
+  /**
+   * Agent startup environment for the run (e.g. hostile-mode knobs). These are
+   * forwarded to the spawned ACP child, not treated as evidence.
+   */
+  readonly agentEnv?: Readonly<Record<string, string>>;
+  /**
+   * Whether the capability was advertised (from a session/initialize probe).
+   * The runner records an observation regardless; the policy derives the
+   * verdict from non-claim verification evidence only (AC #1/#2).
+   */
+  readonly advertised: boolean;
+  readonly policyVersion?: string;
+  /** Extra policy params folded into the recorded PolicySpec (e.g. hysteresis). */
+  readonly policyParams?: Readonly<Record<string, unknown>>;
+}
+
+export interface ConformanceRunResult {
+  readonly observation: CapabilityObservation;
+  readonly effectiveStateView: {
+    readonly capabilityId: CapabilityId;
+    readonly state: string;
+    readonly advertised: boolean;
+  };
+}
+
+export interface ConformanceRunnerShape {
+  readonly run: (input: ConformanceRunInput) => Effect.Effect<ConformanceRunResult, Error>;
+}
+
+export class ConformanceRunner extends ServiceMap.Service<
+  ConformanceRunner,
+  ConformanceRunnerShape
+>()("synara/conformance/ConformanceRunner") {}
+
+export const makeConformanceRunner = Effect.gen(function* () {
+  const registry = yield* CapabilityVerifierRegistry;
+  const evidence = yield* CapabilityEvidenceRepository;
+  const policyEngine = yield* CapabilityPolicyEngine;
+
+  const run: ConformanceRunnerShape["run"] = (input) =>
+    Effect.gen(function* () {
+      // 1. Resolve a verifier for this profile+capability+runtime. No verifier
+      //    means no measurement possible: record nothing (additive contract).
+      const verifier = registry.resolve({
+        capabilityId: input.capabilityId,
+        runtime: input.runtimeIdentity,
+      });
+      if (verifier === undefined) {
+        return yield* Effect.fail(
+          new Error(
+            `No capability verifier resolved for ${input.capabilityId} on namespace ${input.namespace}.`,
+          ),
+        );
+      }
+
+      // 2. Run the verifier in a scratch workspace with a hard timeout. The
+      //    verifier's import (AcpConformanceVerifiers) owns the child-process
+      //    tree teardown; the runner relies on that contract (AC #6).
+      const outcome = yield* verifier.verifies({
+        namespace: input.namespace,
+        capabilityId: input.capabilityId,
+        runtime: input.runtimeIdentity,
+        verifier: { verifierId: verifier.id },
+        advertisement: input.advertised ? { advertised: true } : undefined,
+        spawnContext:
+          input.agentEnv !== undefined
+            ? { command: input.agentCommand, env: input.agentEnv }
+            : { command: input.agentCommand },
+      });
+
+      const observedAt = new Date().toISOString();
+      const policy = makePolicySpec(input.policyVersion ?? CAPABILITY_EVIDENCE_POLICY_VERSION, {
+        ...input.policyParams,
+      });
+
+      // 3. Persist the observation append-only (AC #3).
+      const observation: CapabilityObservation = {
+        observationId: `${input.namespace}:${input.capabilityId}:${observedAt}:${Math.floor(
+          Math.random() * 1e8,
+        )}`,
+        namespace: input.namespace,
+        capabilityId: input.capabilityId,
+        source: CONFORMANCE_EVIDENCE_SOURCE,
+        outcome: outcome.outcome,
+        attribution: outcome.attribution,
+        runtime: input.runtimeIdentity,
+        verifier: { verifierId: verifier.id },
+        policy,
+        observedAt,
+        run: {
+          detail: outcome.detail,
+          completedAt: observedAt,
+        },
+      };
+      yield* evidence.appendObservation({ observation });
+
+      // 4. Re-derive + upsert the effective-state cache for this capability.
+      const past = yield* evidence.listObservations({
+        namespace: input.namespace,
+        capabilityId: input.capabilityId,
+      });
+      const advertisement = input.advertised
+        ? { capabilityId: input.capabilityId, advertised: true, advertisedAt: observedAt }
+        : undefined;
+      const view = policyEngine.deriveEffectiveStateView({
+        namespace: input.namespace,
+        observations: past,
+        policy,
+        advertisement,
+        derivedAt: observedAt,
+      });
+      yield* evidence.upsertEffectiveState({ state: view });
+
+      const result: ConformanceRunResult = {
+        observation,
+        effectiveStateView: {
+          capabilityId: view.capabilityId,
+          state: view.state,
+          advertised: view.advertised,
+        },
+      };
+      return result;
+    });
+
+  return { run } satisfies ConformanceRunnerShape;
+});
+
+export const ConformanceRunnerLive = Layer.effect(ConformanceRunner, makeConformanceRunner);
+
+/** Convenience entry point that runs conformance and returns the edge. */
+export const runConformance = (
+  input: ConformanceRunInput,
+): Effect.Effect<ConformanceRunResult, Error, ConformanceRunner> =>
+  Effect.gen(function* () {
+    const runner = yield* ConformanceRunner;
+    return yield* runner.run(input);
+  });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Verifier registry composition
+
+/** Resolves the ACP hostile fixture relative to this source file. */
+export function fixturePathFromServerDir(): string {
+  return path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../scripts/acp-hostile-agent.ts",
+  );
+}
+
+/**
+ * Registers the ACP conformance verifier bindings into the registry and
+ * provides the registry service. The fixture executable path is resolved at
+ * composition time.
+ */
+export const CapabilityVerifierRegistryLive = Layer.effect(
+  CapabilityVerifierRegistry,
+  Effect.gen(function* () {
+    const registry = yield* makeCapabilityVerifierRegistry;
+    makeAcpVerifierRegistry({
+      fixturePath: fixturePathFromServerDir(),
+      register: (verifier) => registry.register(verifier),
+    });
+    return registry;
+  }),
+);

--- a/apps/server/src/conformance/ConformanceScratchWorkspace.ts
+++ b/apps/server/src/conformance/ConformanceScratchWorkspace.ts
@@ -1,0 +1,78 @@
+// FILE: ConformanceScratchWorkspace.ts
+// Purpose: Per-run scratch working directory for conformance verifications.
+// Layer: Server conformance filesystem utility
+// Exports: withConformanceScratchWorkspace, makeConformanceScratchWorkspace
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { Effect, Layer, Option, Scope, ServiceMap } from "effect";
+
+/**
+ * Creates a fresh per-run scratch directory under the platform temp dir and
+ * removes it when the scope closes. `rmSync(force: true)` is used on release,
+ * so cleanup never throws even if the hostile agent left locked or recreated
+ * files behind.
+ */
+export const withConformanceScratchWorkspace: <A, E, R>(
+  use: (workspace: string) => Effect.Effect<A, E, R>,
+) => Effect.Effect<A, E, R | Scope.Scope> = (use) =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const directory = mkdtempSync(path.join(tmpdir(), "synara-conformance-"));
+      return directory;
+    }),
+    (directory) =>
+      Effect.sync(() => {
+        rmSync(directory, { recursive: true, force: true });
+      }),
+  ).pipe(Effect.flatMap(use));
+
+/**
+ * Service-based variant so the runner can depend on a single service rather
+ * than building scopes ad-hoc in each verifier.
+ */
+export interface ConformanceScratchWorkspaceShape {
+  /**
+   * Runs `use` inside a scope that guarantees the scratch directory is removed
+   * when the effect completes or fails. Also bounded by `runTimeoutMs` when
+   * provided, so a misbehaving verifier can never leak a workspace.
+   */
+  readonly inScratchWorkspace: <A, E, R>(
+    use: (workspace: string) => Effect.Effect<A, E, R>,
+    runTimeoutMs?: number,
+  ) => Effect.Effect<A, E | Error, R | Scope.Scope>;
+}
+
+export class ConformanceScratchWorkspace extends ServiceMap.Service<
+  ConformanceScratchWorkspace,
+  ConformanceScratchWorkspaceShape
+>()("synara/conformance/ConformanceScratchWorkspace") {}
+
+export const makeConformanceScratchWorkspace: Effect.Effect<ConformanceScratchWorkspaceShape> =
+  Effect.sync(
+    (): ConformanceScratchWorkspaceShape => ({
+      inScratchWorkspace: (use, runTimeoutMs) => {
+        const scoped = withConformanceScratchWorkspace(use);
+        if (runTimeoutMs === undefined) return scoped;
+        return scoped.pipe(
+          Effect.timeoutOption(runTimeoutMs),
+          Effect.flatMap((maybe) =>
+            Option.isNone(maybe)
+              ? Effect.fail(
+                  new Error(
+                    `Conformance run exceeded the ${String(runTimeoutMs)}ms hard deadline.`,
+                  ),
+                )
+              : Effect.succeed(maybe.value),
+          ),
+        );
+      },
+    }),
+  );
+
+export const ConformanceScratchWorkspaceLive = Layer.effect(
+  ConformanceScratchWorkspace,
+  makeConformanceScratchWorkspace,
+);

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -298,10 +298,11 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [94, "ProjectionThreadsGoal"],
         [95, "ProjectionThreadsGoalTiming"],
         [96, "ProjectionThreadsGoalAchievements"],
+        [98, "CapabilityEvidence"],
       ]);
 
       const tracker = yield* trackerRows(sql);
-      assert.deepStrictEqual(tracker.slice(-42), [
+      assert.deepStrictEqual(tracker.slice(-43), [
         { migration_id: 55, name: "ManagedAttachments" },
         { migration_id: 56, name: "CommandReceiptFingerprints" },
         { migration_id: 57, name: "ThreadScopedProjectionMessageIdentity" },
@@ -344,6 +345,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         { migration_id: 94, name: "ProjectionThreadsGoal" },
         { migration_id: 95, name: "ProjectionThreadsGoalTiming" },
         { migration_id: 96, name: "ProjectionThreadsGoalAchievements" },
+        { migration_id: 98, name: "CapabilityEvidence" },
       ]);
       const preserved = yield* sql<{ readonly count: number }>`
         SELECT COUNT(*) AS count FROM orchestration_consumer_state
@@ -432,6 +434,7 @@ agentGatewayRetentionLegacyLayer(
           [94, "ProjectionThreadsGoal"],
           [95, "ProjectionThreadsGoalTiming"],
           [96, "ProjectionThreadsGoalAchievements"],
+          [98, "CapabilityEvidence"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -523,11 +526,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [94, "ProjectionThreadsGoal"],
         [95, "ProjectionThreadsGoalTiming"],
         [96, "ProjectionThreadsGoalAchievements"],
+        [98, "CapabilityEvidence"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-26).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-27).map((row) => [row.migration_id, row.name]),
         [
           [71, "ProjectionThreadsGatewayProvenance"],
           [72, "AgentGatewayOperationRetention"],
@@ -555,6 +559,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [94, "ProjectionThreadsGoal"],
           [95, "ProjectionThreadsGoalTiming"],
           [96, "ProjectionThreadsGoalAchievements"],
+          [98, "CapabilityEvidence"],
         ],
       );
 
@@ -641,11 +646,12 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [94, "ProjectionThreadsGoal"],
         [95, "ProjectionThreadsGoalTiming"],
         [96, "ProjectionThreadsGoalAchievements"],
+        [98, "CapabilityEvidence"],
       ]);
 
       const tracker = yield* trackerRows(sql);
       assert.deepStrictEqual(
-        tracker.slice(-22).map((row) => [row.migration_id, row.name]),
+        tracker.slice(-23).map((row) => [row.migration_id, row.name]),
         [
           [75, "ExternalMcpActiveCapacity"],
           [76, "ExternalMcpHardening"],
@@ -669,6 +675,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [94, "ProjectionThreadsGoal"],
           [95, "ProjectionThreadsGoalTiming"],
           [96, "ProjectionThreadsGoalAchievements"],
+          [98, "CapabilityEvidence"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -112,6 +112,7 @@ import Migration0093 from "./Migrations/093_BackfillMaxIterationsDisabledReason.
 import Migration0094 from "./Migrations/094_ProjectionThreadsGoal.ts";
 import Migration0095 from "./Migrations/095_ProjectionThreadsGoalTiming.ts";
 import Migration0096 from "./Migrations/096_ProjectionThreadsGoalAchievements.ts";
+import Migration0098 from "./Migrations/098_CapabilityEvidence.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -223,6 +224,7 @@ export const migrationEntries = [
   [94, "ProjectionThreadsGoal", Migration0094],
   [95, "ProjectionThreadsGoalTiming", Migration0095],
   [96, "ProjectionThreadsGoalAchievements", Migration0096],
+  [98, "CapabilityEvidence", Migration0098],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/098_CapabilityEvidence.test.ts
+++ b/apps/server/src/persistence/Migrations/098_CapabilityEvidence.test.ts
@@ -1,0 +1,86 @@
+// FILE: 098_CapabilityEvidence.test.ts
+// Purpose: Proves migration 98 creates an append-only capability observations
+// store and is idempotent across replays (MigrationReplay re-runs every
+// migration at or after id 54 over its own post-state).
+// Layer: SQLite migration test
+
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { describe } from "vitest";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+describe("098_CapabilityEvidence", () => {
+  it.effect("creates the capability_observations table and its index", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 97 });
+
+      assert.deepStrictEqual(yield* runMigrations({ toMigrationInclusive: 98 }), [
+        [98, "CapabilityEvidence"],
+      ]);
+
+      const [table] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'capability_observations'
+        ) AS "exists"
+      `;
+      assert.strictEqual(table?.exists, 1);
+
+      const [index] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'capability_observations_namespace_idx'
+        ) AS "exists"
+      `;
+      assert.strictEqual(index?.exists, 1);
+
+      // The store is append-only: no PITR-style columns that could be targeted
+      // by an upsert-like backfill, only identity + payload + tombstone-free rows.
+      const columns = yield* sql<{ readonly name: string }>`
+        SELECT name FROM pragma_table_info('capability_observations') ORDER BY name
+      `;
+      assert.deepStrictEqual(
+        columns.map((column) => column.name),
+        [
+          "attribution",
+          "capability_id",
+          "created_at",
+          "namespace",
+          "observation_id",
+          "observed_at",
+          "outcome",
+          "policy_json",
+          "run_metadata_json",
+          "runtime_identity_json",
+          "source",
+          "verifier_json",
+        ],
+      );
+
+      const [effectiveTable] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'capability_effective_states'
+        ) AS "exists"
+      `;
+      assert.strictEqual(effectiveTable?.exists, 1);
+    }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+  );
+
+  it.effect("is idempotent when re-run over its own post-state", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 98 });
+
+      assert.deepStrictEqual(yield* runMigrations({ toMigrationInclusive: 98 }), []);
+
+      const [table] = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'capability_observations'
+        ) AS "exists"
+      `;
+      assert.strictEqual(table?.exists, 1);
+    }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+  );
+});

--- a/apps/server/src/persistence/Migrations/098_CapabilityEvidence.ts
+++ b/apps/server/src/persistence/Migrations/098_CapabilityEvidence.ts
@@ -1,0 +1,61 @@
+// FILE: 098_CapabilityEvidence.ts
+// Purpose: Creates the append-only capability observation store for the
+// canonical capability/evidence model (KAR-523). Observations are immutable
+// facts about what an external agent runtime demonstrated or advertised; the
+// effective capability state is always derived from this history, never stored
+// as a single mutable flag.
+
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { tableExists } from "./schemaHelpers.ts";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  if (!(yield* tableExists(sql, "capability_observations"))) {
+    yield* sql`
+      CREATE TABLE capability_observations (
+        observation_id TEXT PRIMARY KEY,
+        namespace TEXT NOT NULL,
+        capability_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        attribution TEXT NOT NULL,
+        runtime_identity_json TEXT NOT NULL,
+        verifier_json TEXT NOT NULL,
+        policy_json TEXT NOT NULL,
+        observed_at TEXT NOT NULL,
+        run_metadata_json TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      )
+    `;
+
+    yield* sql`
+      CREATE INDEX capability_observations_namespace_idx
+      ON capability_observations (namespace, capability_id, observed_at)
+    `;
+  }
+
+  // Derived cache of effective capability state per (namespace, capability).
+  // Deliberately NOT the source of truth: it is recomputable from the append-only
+  // observation history via `deriveEffectiveState`, and it is the only table in
+  // this module that is ever updated (by re-derivation or explicit invalidation).
+  if (!(yield* tableExists(sql, "capability_effective_states"))) {
+    yield* sql`
+      CREATE TABLE capability_effective_states (
+        namespace TEXT NOT NULL,
+        capability_id TEXT NOT NULL,
+        state TEXT NOT NULL,
+        advertised INTEGER NOT NULL DEFAULT 0,
+        policy_json TEXT NOT NULL,
+        last_observation_at TEXT,
+        last_observation_id TEXT,
+        derived_at TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        PRIMARY KEY (namespace, capability_id)
+      )
+    `;
+  }
+});

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -40,7 +40,6 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -72,6 +71,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   makeAcpThreadLock,
   readAcpUsdCost,
@@ -741,16 +741,10 @@ export function makeCursorAdapter(
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientInfo: { name: "Synara", version: "0.0.0" },
             startupTimeouts: CURSOR_ACP_STARTUP_TIMEOUTS,
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpNativeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/Layers/DroidAdapter.ts
+++ b/apps/server/src/provider/Layers/DroidAdapter.ts
@@ -39,7 +39,6 @@ import {
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -74,6 +73,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
@@ -864,16 +864,10 @@ export function makeDroidAdapter(
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientCapabilities: { elicitation: { form: {} } },
             clientInfo: { name: "Synara", version: "0.0.0" },
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult: Acp.InitializeResponse) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpRuntimeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -42,7 +42,6 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import type * as Acp from "@agentclientprotocol/sdk";
 
-import { buildAcpSynaraMcpServers } from "../../agentGateway/mcpInjection.ts";
 import {
   type SynaraHarnessPolicyDeliveryState,
   takeSynaraHarnessPolicyTextPartForProviderSession,
@@ -75,6 +74,7 @@ import {
   selectAcpPermissionOptionId,
 } from "../acp/AcpAdapterSupport.ts";
 import {
+  buildAcpGatewayMcpServers,
   acceptAcpPlanUpdate,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
@@ -1111,16 +1111,10 @@ export function makeGrokAdapter(
             // initialize.clientCapabilities. Re-send this on load/resume so a
             // reconnected session keeps the Plan-mode write gate.
             sessionMeta: GROK_SESSION_META,
-            ...(agentGatewayCredentials
-              ? {
-                  buildMcpServers: (initializeResult) =>
-                    buildAcpSynaraMcpServers({
-                      connection: gatewaySessionLease!.connection,
-                      initializeResult,
-                      stdioProxy: agentGatewayCredentials.stdioProxy,
-                    }),
-                }
-              : {}),
+            ...buildAcpGatewayMcpServers({
+              gatewaySessionLease,
+              agentGatewayCredentials,
+            }),
             ...acpRuntimeLoggers,
           }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),

--- a/apps/server/src/provider/acp/AcpAdapterSessionSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSessionSupport.test.ts
@@ -1,7 +1,10 @@
 import { ThreadId, TurnId, type ProviderSession } from "@synara/contracts";
+
+import { SYNARA_AGENT_GATEWAY_TOKEN_ENV } from "../../agentGateway/mcpInjection.ts";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAcpGatewayMcpServers,
   clearAcpActiveTurn,
   finalizeAcpActiveTurnCost,
   recordAcpSessionCost,
@@ -211,5 +214,60 @@ describe("ACP adapter session support", () => {
         homeDir: "/home/test",
       }),
     ).toBe("/server");
+  });
+});
+
+describe("buildAcpGatewayMcpServers", () => {
+  const connection = {
+    url: "http://127.0.0.1:3773/mcp",
+    bearerToken: "sagw_abc.def",
+  };
+  const stdioProxy = {
+    command: "/usr/local/bin/node",
+    args: ["/state/agent-gateway-mcp-proxy.mjs"],
+  };
+
+  it("builds an HTTP gateway server when the agent advertises http support", () => {
+    const options = buildAcpGatewayMcpServers({
+      gatewaySessionLease: { connection },
+      agentGatewayCredentials: { stdioProxy },
+    });
+    expect(
+      options.buildMcpServers?.({ agentCapabilities: { mcpCapabilities: { http: true } } }),
+    ).toEqual([
+      {
+        type: "http",
+        name: "synara",
+        url: connection.url,
+        headers: [{ name: "Authorization", value: `Bearer ${connection.bearerToken}` }],
+      },
+    ]);
+  });
+
+  it("falls back to the stdio proxy when http is not advertised", () => {
+    const options = buildAcpGatewayMcpServers({
+      gatewaySessionLease: { connection },
+      agentGatewayCredentials: { stdioProxy },
+    });
+    expect(options.buildMcpServers?.({})).toEqual([
+      {
+        name: "synara",
+        command: stdioProxy.command,
+        args: stdioProxy.args,
+        env: [
+          { name: "SYNARA_AGENT_GATEWAY_URL", value: connection.url },
+          { name: SYNARA_AGENT_GATEWAY_TOKEN_ENV, value: connection.bearerToken },
+        ],
+      },
+    ]);
+  });
+
+  it("skips gateway injection when the gateway is not running", () => {
+    expect(
+      buildAcpGatewayMcpServers({
+        gatewaySessionLease: undefined,
+        agentGatewayCredentials: undefined,
+      }),
+    ).toEqual({});
   });
 });

--- a/apps/server/src/provider/acp/AcpAdapterSessionSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSessionSupport.ts
@@ -16,6 +16,14 @@ import type {
 import { Deferred, Effect, Option, Semaphore, SynchronizedRef } from "effect";
 import type * as Acp from "@agentclientprotocol/sdk";
 
+import {
+  buildAcpSynaraMcpServers,
+  type AcpInitializeCapabilitiesView,
+} from "../../agentGateway/mcpInjection.ts";
+import type {
+  AgentGatewayMcpConnection,
+  AgentGatewayStdioProxySpawn,
+} from "../../agentGateway/Services/AgentGatewayCredentials.ts";
 import type { AcpSessionMode, AcpSessionModeState, AcpToolCallState } from "./AcpRuntimeModel.ts";
 
 export interface AcpSessionModeAliases {
@@ -272,4 +280,36 @@ export function acceptAcpPlanUpdate(
   if (context.lastPlanFingerprint === fingerprint) return false;
   context.lastPlanFingerprint = fingerprint;
   return true;
+}
+
+/**
+ * Builds the `buildMcpServers` runtime option from a live agent gateway lease.
+ *
+ * Shared by every ACP adapter so gateway injection rules cannot drift between
+ * first-party agents and future generic ACP agents. The result is spread into
+ * `AcpSessionRuntimeOptions`; it is empty when the gateway is not running, so
+ * ACP sessions then start without gateway injection. The builder negotiates
+ * the transport from the agent's advertised `mcpCapabilities`: streamable HTTP
+ * when supported, otherwise the stdio -> HTTP proxy that keeps the bearer
+ * token out of provider processes.
+ */
+export function buildAcpGatewayMcpServers(input: {
+  readonly gatewaySessionLease: { readonly connection: AgentGatewayMcpConnection } | undefined;
+  readonly agentGatewayCredentials:
+    | { readonly stdioProxy: AgentGatewayStdioProxySpawn }
+    | undefined;
+}): {
+  readonly buildMcpServers?: (
+    initializeResult: AcpInitializeCapabilitiesView,
+  ) => Array<Acp.McpServer>;
+} {
+  if (input.gatewaySessionLease === undefined || input.agentGatewayCredentials === undefined) {
+    return {};
+  }
+  const { connection } = input.gatewaySessionLease;
+  const { stdioProxy } = input.agentGatewayCredentials;
+  return {
+    buildMcpServers: (initializeResult) =>
+      buildAcpSynaraMcpServers({ connection, initializeResult, stdioProxy }),
+  };
 }

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -1,9 +1,16 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it as effectIt } from "@effect/vitest";
 import { describe, expect, it } from "vitest";
 
 import { Deferred, Effect, Exit, Scope } from "effect";
 import type * as Acp from "@agentclientprotocol/sdk";
 
 import {
+  AcpSessionRuntime,
+  type AcpSessionRequestLogEvent,
   assistantItemId,
   awaitAcpChildExit,
   decodeSetSessionConfigOptionResponse,
@@ -230,5 +237,73 @@ describe("sessionConfigOptionsFromSetup", () => {
 
   it("uses an explicit setup inventory instead of replayed config", () => {
     expect(sessionConfigOptionsFromSetup({ configOptions: [] }, replayedConfigOptions)).toEqual([]);
+  });
+});
+
+describe("startup authentication negotiation", () => {
+  const bunExe = process.execPath;
+  const mockAgentPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/acp-mock-agent.ts",
+  );
+  const conformanceAgentPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../scripts/acp-conformance-agent.ts",
+  );
+
+  effectIt.effect("starts a no-auth agent and skips authenticate", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const started = yield* runtime.start();
+
+      expect(started.sessionId).toBe("mock-session-1");
+      expect(started.sessionSetupMethod).toBe("new");
+      expect(requestEvents.filter((event) => event.method === "authenticate")).toEqual([]);
+      expect(
+        requestEvents.some((event) => event.method === "session/new" && event.status === "started"),
+      ).toBe(true);
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [mockAgentPath],
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+          requestLogger: (event) =>
+            Effect.sync(() => {
+              requestEvents.push(event);
+            }),
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
+  });
+
+  effectIt.effect("keeps failing when an agent advertises methods but none resolve", () => {
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      const failure = yield* runtime.start().pipe(Effect.flip);
+      expect(failure._tag).toBe("AcpRequestError");
+      if (failure._tag === "AcpRequestError") {
+        expect(failure.errorMessage).toBe("ACP agent did not provide an authentication method.");
+      }
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: bunExe,
+            args: [conformanceAgentPath],
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -1081,33 +1081,39 @@ const makeAcpSessionRuntime = (
         startupTimeouts.initializeMs,
         runLoggedRequest("initialize", initializePayload, acp.agent.initialize(initializePayload)),
       );
+      const advertisedAuthMethods = initializeResult.authMethods ?? [];
       const authMethodId =
         options.resolveAuthMethodId !== undefined
           ? yield* options.resolveAuthMethodId(initializeResult)
           : options.authMethodId;
 
-      if (!authMethodId) {
-        return yield* new AcpErrors.AcpRequestError({
-          code: -32602,
-          errorMessage: "ACP agent did not provide an authentication method.",
-          data: { authMethods: initializeResult.authMethods ?? [] },
-        });
-      }
+      // Agents that advertise no auth methods require no authenticate step;
+      // requiring one here would make any no-auth agent unstartable. The error
+      // is only for agents that advertise methods but none resolve.
+      if (advertisedAuthMethods.length > 0) {
+        if (!authMethodId) {
+          return yield* new AcpErrors.AcpRequestError({
+            code: -32602,
+            errorMessage: "ACP agent did not provide an authentication method.",
+            data: { authMethods: advertisedAuthMethods },
+          });
+        }
 
-      const authenticatePayload = {
-        methodId: authMethodId,
-        ...(options.authenticateMeta ? { _meta: options.authenticateMeta } : {}),
-      } satisfies Acp.AuthenticateRequest;
+        const authenticatePayload = {
+          methodId: authMethodId,
+          ...(options.authenticateMeta ? { _meta: options.authenticateMeta } : {}),
+        } satisfies Acp.AuthenticateRequest;
 
-      yield* withStartupTimeout(
-        "authenticate",
-        startupTimeouts.authenticateMs,
-        runLoggedRequest(
+        yield* withStartupTimeout(
           "authenticate",
-          authenticatePayload,
-          acp.agent.authenticate(authenticatePayload),
-        ),
-      );
+          startupTimeouts.authenticateMs,
+          runLoggedRequest(
+            "authenticate",
+            authenticatePayload,
+            acp.agent.authenticate(authenticatePayload),
+          ),
+        );
+      }
 
       const mcpServers = options.buildMcpServers?.(initializeResult) ?? [];
 

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -44,6 +44,7 @@ import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResol
 import { ExternalMcpRepositoryLive } from "./externalMcp/Layers/ExternalMcpRepository";
 import { ExternalMcpServiceLive } from "./externalMcp/Layers/ExternalMcpService";
 import { ExternalMcpGatewayLive } from "./externalMcp/Layers/ExternalMcpGateway";
+import { capabilityEvidenceLayer } from "./capabilityEvidence/Layers/CapabilityEvidenceService";
 import { ServerEnvironmentLive } from "./environment/Layers/ServerEnvironment";
 import { AutomationRepositoryLive } from "./persistence/Layers/AutomationRepository";
 import { ProjectPullRequestPinsLive } from "./persistence/Layers/ProjectPullRequestPins";
@@ -188,6 +189,7 @@ export function makeServerRuntimeServicesLayer(
     Layer.provideMerge(ServerSettingsLive),
     Layer.provideMerge(providerHealthLayer),
   );
+  const capabilityEvidenceServiceLayer = capabilityEvidenceLayer;
   const agentGatewayLayer = AgentGatewayLive.pipe(
     Layer.provideMerge(agentGatewayCredentialsLayer),
     Layer.provideMerge(automationServiceLayer),
@@ -224,6 +226,7 @@ export function makeServerRuntimeServicesLayer(
     ExternalMcpRepositoryLive,
     externalMcpServiceLayer,
     externalMcpGatewayLayer,
+    capabilityEvidenceServiceLayer,
     providerHealthLayer,
     ProjectPullRequestPinsLive,
     pullRequestServiceLayer,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -107,6 +107,7 @@ import { ProfileStatsQuery } from "./profileStats";
 import { redactSensitiveProcessArgs } from "./processArgumentRedaction";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment";
 import { ExternalMcpService } from "./externalMcp/Services/ExternalMcpService";
+import { CapabilityEvidenceService } from "./capabilityEvidence/Services/CapabilityEvidenceService";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup";
 import { ServerSettingsService } from "./serverSettings";
@@ -340,6 +341,7 @@ const makeWsRpcHandlersLayer = () =>
       const devServerManager = yield* DevServerManager;
       const fileSystem = yield* FileSystem.FileSystem;
       const externalMcp = yield* ExternalMcpService;
+      const capabilityEvidence = yield* CapabilityEvidenceService;
       const git = yield* GitCore;
       const github = yield* GitHubCli;
       const gitManager = yield* GitManager;
@@ -1651,6 +1653,15 @@ const makeWsRpcHandlersLayer = () =>
           rpcEffect(
             requireOwner.pipe(Effect.andThen(externalMcp.refreshPairing(input))),
             "Failed to refresh external MCP pairing",
+          ),
+        [WS_METHODS.capabilityEvidenceRecord]: (input) =>
+          rpcEffect(capabilityEvidence.record(input), "Failed to record capability evidence"),
+        [WS_METHODS.capabilityEvidenceQuery]: (input) =>
+          rpcEffect(capabilityEvidence.query(input), "Failed to query capability evidence"),
+        [WS_METHODS.capabilityEvidenceInvalidate]: (input) =>
+          rpcEffect(
+            capabilityEvidence.invalidate(input),
+            "Failed to invalidate capability evidence",
           ),
         [WS_METHODS.serverListWorktrees]: () =>
           rpcEffect(

--- a/packages/contracts/src/capabilityEvidence.ts
+++ b/packages/contracts/src/capabilityEvidence.ts
@@ -1,0 +1,265 @@
+import { Schema } from "effect";
+
+import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
+import { ProviderKind } from "./orchestration";
+
+/**
+ * Canonical capability identifiers for external agents.
+ *
+ * These are protocol-independent. Each capability names a behavior the
+ * application needs from an external agent, not any particular wire method, so
+ * evidence recorded for one protocol (say ACP) applies to any other runtime
+ * that exposes the same behavior. KAR-524 binds real verifiers to these ids.
+ */
+export const CapabilityId = Schema.Literals([
+  "session.start",
+  "prompt",
+  "stream",
+  "cancel",
+  "session.resume",
+  "permissions",
+  "elicitation",
+  "tool.events",
+  "model.discovery",
+  "model.switch",
+  "modes",
+  "usage",
+  "terminal.state",
+]);
+export type CapabilityId = typeof CapabilityId.Type;
+
+/** The 13 canonical capability ids, kept in sync with the CapabilityId literal union. */
+export const CAPABILITY_IDS: readonly CapabilityId[] = [
+  "session.start",
+  "prompt",
+  "stream",
+  "cancel",
+  "session.resume",
+  "permissions",
+  "elicitation",
+  "tool.events",
+  "model.discovery",
+  "model.switch",
+  "modes",
+  "usage",
+  "terminal.state",
+] as const;
+
+/**
+ * Key identifying one external agent configuration: the kind of provider
+ * runtime plus the profile id that selects it. Kept as a plain namespace
+ * string so the rest of the protocol-independent layer never depends on
+ * ACP-specific session ids.
+ */
+export const ExternalAgentNamespace = TrimmedNonEmptyString.check(Schema.isMaxLength(128));
+export type ExternalAgentNamespace = typeof ExternalAgentNamespace.Type;
+
+/**
+ * Where an observation came from.
+ *
+ * - `protocol-claim`: the agent advertised it, or a protocol handshake asserted it
+ * - `synthetic-conformance`: a Conformance suite exercised the behavior
+ * - `production-observation`: a real user session exercised the behavior
+ * - `vendor-attestation`: the agent vendor published a statement about it
+ */
+export const EvidenceSource = Schema.Literals([
+  "protocol-claim",
+  "synthetic-conformance",
+  "production-observation",
+  "vendor-attestation",
+]);
+export type EvidenceSource = typeof EvidenceSource.Type;
+
+export const EvidenceOutcome = Schema.Literals(["pass", "fail", "inconclusive"]);
+export type EvidenceOutcome = typeof EvidenceOutcome.Type;
+
+/** Who owns the failure when a capability did not verify. */
+export const Attribution = Schema.Literals([
+  "agent",
+  "synara",
+  "auth",
+  "network",
+  "environment",
+  "unknown",
+]);
+export type Attribution = typeof Attribution.Type;
+
+/**
+ * The identity of the external agent runtime that produced or was observed
+ * during an observation.
+ *
+ * Multiple independent signals because any single one can silently change
+ * without meaning the whole product changed. Signal-specific staleness means
+ * an upgrade to one signal marks only the evidence that referenced it as
+ * provisional, never every record.
+ */
+export const RuntimeIdentitySignals = Schema.Struct({
+  agentName: Schema.optional(Schema.String.check(Schema.isMaxLength(256))),
+  agentVersion: Schema.optional(Schema.String.check(Schema.isMaxLength(256))),
+  protocolVersion: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+  advertisedContractHash: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+  resolvedEndpoint: Schema.optional(Schema.String.check(Schema.isMaxLength(1024))),
+  resolvedCommand: Schema.optional(Schema.String.check(Schema.isMaxLength(1024))),
+  packageFingerprint: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+  runtimeFingerprint: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+});
+export type RuntimeIdentitySignals = typeof RuntimeIdentitySignals.Type;
+
+/**
+ * Identity of the verifier that produced an observation, including the shared
+ * harness version. A harness change means previously recorded verification
+ * outcomes may no longer hold, so policy re-derivation must fold the harness
+ * version into the verifier identity.
+ */
+export const VerifierIdentity = Schema.Struct({
+  verifierId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  harnessVersion: Schema.optional(Schema.String.check(Schema.isMaxLength(128))),
+});
+export type VerifierIdentity = typeof VerifierIdentity.Type;
+
+/**
+ * The policy that decided whether an observation is trustworthy. Versioned so
+ * verdicts can be re-derived without re-running the observation: bump the
+ * policy version, recompute `deriveEffectiveState`, and the verdict follows
+ * the new calibration on the same immutable observation history.
+ */
+export const PolicyVersion = TrimmedNonEmptyString.check(Schema.isMaxLength(128));
+export type PolicyVersion = typeof PolicyVersion.Type;
+
+export const PolicySpec = Schema.Struct({
+  version: PolicyVersion,
+  // Policy constants are deliberately freeform: each engine version owns how
+  // it interprets them (hysteresis window, debounce, thresholds). KAR-523 pins
+  // the wiring in the policy engine; KAR-524 may add more knobs.
+  params: Schema.Record(Schema.String, Schema.Unknown),
+});
+export type PolicySpec = typeof PolicySpec.Type;
+
+export const ObservationRunMetadata = Schema.Struct({
+  threadId: Schema.optional(Schema.String),
+  turnId: Schema.optional(Schema.String),
+  // Protocol-level session identity if one exists (e.g. an ACP session id).
+  runtimeSessionId: Schema.optional(Schema.String),
+  startedAt: Schema.optional(IsoDateTime),
+  completedAt: Schema.optional(IsoDateTime),
+  detail: Schema.optional(Schema.String),
+});
+export type ObservationRunMetadata = typeof ObservationRunMetadata.Type;
+
+/**
+ * A single immutable observation of one capability. Append-only: it is never
+ * edited and never represents the "current" truth about a capability. Only the
+ * effective state derived from a run of observations is meaningful.
+ */
+export const CapabilityObservation = Schema.Struct({
+  observationId: TrimmedNonEmptyString,
+  namespace: ExternalAgentNamespace,
+  capabilityId: CapabilityId,
+  source: EvidenceSource,
+  outcome: EvidenceOutcome,
+  attribution: Attribution,
+  runtime: RuntimeIdentitySignals,
+  verifier: VerifierIdentity,
+  policy: PolicySpec,
+  observedAt: IsoDateTime,
+  run: Schema.optional(ObservationRunMetadata),
+});
+export type CapabilityObservation = typeof CapabilityObservation.Type;
+
+/** User-facing state of a capability for an external agent profile. */
+export const EffectiveCapabilityState = Schema.Literals([
+  // Believes the capability works (e.g. verified through conformance).
+  "verified",
+  // Evidence exists but is stale or its verifier/policy has changed.
+  "provisional",
+  // No usable evidence: either unknown to the profile or known but discarded.
+  "unknown",
+  // The capability is believed degraded: it works sometimes, or stalls.
+  "degraded",
+  // The capability is believed broken (e.g. advertised but verification failed).
+  "broken",
+]);
+export type EffectiveCapabilityState = typeof EffectiveCapabilityState.Type;
+
+/** One capability advertisement from a protocol-initiated capability probe. */
+export const CapabilityAdvertisement = Schema.Struct({
+  capabilityId: CapabilityId,
+  advertised: Schema.Boolean,
+  // When the protocol cannot say whether the capability is supported, `true`
+  // keeps the additive-contract property: new capabilities read as unknown
+  // for profiles that predate them.
+  advertisedAt: IsoDateTime,
+});
+export type CapabilityAdvertisement = typeof CapabilityAdvertisement.Type;
+
+/**
+ * The derived effective state of one capability for one external agent profile.
+ *
+ * `effective` couples the user-facing verdict with the evidence that supports
+ * it. `advertised` stays separate because advertisement and verification are
+ * independent dimensions: `advertised: true` + `effective: "broken"` is a
+ * representable, meaningful state (capability disabled), and `advertised: false`
+ * + `effective: "verified"` means the agent did not claim it but it demonstrably
+ * works.
+ */
+export const EffectiveCapabilityStateView = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: CapabilityId,
+  state: EffectiveCapabilityState,
+  advertised: Schema.Boolean,
+  policy: PolicySpec,
+  // The most recent observation that participated in the verdict, if any, plus
+  // timestamps to make staleness plain to consumers.
+  lastObservationAt: Schema.optional(IsoDateTime),
+  lastObservationId: Schema.optional(TrimmedNonEmptyString),
+  derivedAt: IsoDateTime,
+});
+export type EffectiveCapabilityStateView = typeof EffectiveCapabilityStateView.Type;
+
+export const CapabilityEvidenceRecordInput = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: CapabilityId,
+  source: EvidenceSource,
+  outcome: EvidenceOutcome,
+  attribution: Attribution,
+  runtime: RuntimeIdentitySignals,
+  verifier: VerifierIdentity,
+  policy: PolicySpec,
+  observedAt: IsoDateTime,
+  run: Schema.optional(ObservationRunMetadata),
+});
+export type CapabilityEvidenceRecordInput = typeof CapabilityEvidenceRecordInput.Type;
+
+export const CapabilityEvidenceQuery = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: Schema.optional(CapabilityId),
+});
+export type CapabilityEvidenceQuery = typeof CapabilityEvidenceQuery.Type;
+
+export const CapabilityEvidenceQueryResult = Schema.Struct({
+  observations: Schema.Array(CapabilityObservation),
+  state: Schema.optional(EffectiveCapabilityStateView),
+});
+export type CapabilityEvidenceQueryResult = typeof CapabilityEvidenceQueryResult.Type;
+
+export const CapabilityEvidenceRecordResult = Schema.Struct({
+  observation: CapabilityObservation,
+});
+export type CapabilityEvidenceRecordResult = typeof CapabilityEvidenceRecordResult.Type;
+
+export const CapabilityEvidenceInvalidateInput = Schema.Struct({
+  namespace: ExternalAgentNamespace,
+  capabilityId: Schema.optional(CapabilityId),
+});
+export type CapabilityEvidenceInvalidateInput = typeof CapabilityEvidenceInvalidateInput.Type;
+
+export const CapabilityEvidenceInvalidateResult = Schema.Struct({
+  invalidated: Schema.Number,
+});
+export type CapabilityEvidenceInvalidateResult = typeof CapabilityEvidenceInvalidateResult.Type;
+
+export const ExternalAgentProfileId = TrimmedNonEmptyString;
+export type ExternalAgentProfileId = typeof ExternalAgentProfileId.Type;
+
+export const ExternalAgentKind = ProviderKind;
+export type ExternalAgentKind = typeof ExternalAgentKind.Type;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,6 +16,7 @@ export * from "./terminal";
 export * from "./provider";
 export * from "./providerDiscovery";
 export * from "./providerRuntime";
+export * from "./capabilityEvidence";
 export * from "./model";
 export * from "./agentMentions";
 export * from "./agentGateway";

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -22,6 +22,14 @@ import {
   AutomationStreamEvent,
   AutomationUpdateInput,
 } from "./automation";
+import {
+  CapabilityEvidenceInvalidateInput,
+  CapabilityEvidenceInvalidateResult,
+  CapabilityEvidenceQuery,
+  CapabilityEvidenceQueryResult,
+  CapabilityEvidenceRecordInput,
+  CapabilityEvidenceRecordResult,
+} from "./capabilityEvidence";
 import { OpenInEditorInput } from "./editor";
 import {
   ExternalMcpCreateIntegrationInput,
@@ -960,6 +968,24 @@ export const WsServerRefreshExternalMcpPairingRpc = Rpc.make(
   },
 );
 
+export const WsCapabilityEvidenceRecordRpc = Rpc.make(WS_METHODS.capabilityEvidenceRecord, {
+  payload: CapabilityEvidenceRecordInput,
+  success: CapabilityEvidenceRecordResult,
+  error: WsRpcError,
+});
+
+export const WsCapabilityEvidenceQueryRpc = Rpc.make(WS_METHODS.capabilityEvidenceQuery, {
+  payload: CapabilityEvidenceQuery,
+  success: CapabilityEvidenceQueryResult,
+  error: WsRpcError,
+});
+
+export const WsCapabilityEvidenceInvalidateRpc = Rpc.make(WS_METHODS.capabilityEvidenceInvalidate, {
+  payload: CapabilityEvidenceInvalidateInput,
+  success: CapabilityEvidenceInvalidateResult,
+  error: WsRpcError,
+});
+
 export const WsServerListWorktreesRpc = Rpc.make(WS_METHODS.serverListWorktrees, {
   payload: Schema.Struct({}),
   success: ServerListWorktreesResult,
@@ -1284,6 +1310,9 @@ export const WsFeatureRpcGroup = RpcGroup.make(
   WsServerCreateExternalMcpIntegrationRpc,
   WsServerRevokeExternalMcpIntegrationRpc,
   WsServerRefreshExternalMcpPairingRpc,
+  WsCapabilityEvidenceRecordRpc,
+  WsCapabilityEvidenceQueryRpc,
+  WsCapabilityEvidenceInvalidateRpc,
   WsServerListWorktreesRpc,
   WsServerListLocalServersRpc,
   WsServerStopLocalServerRpc,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -157,6 +157,11 @@ import {
   GitHubProjectProvisionInput,
   GitHubProjectProvisionProgressEvent,
 } from "./githubProjectProvisioning";
+import {
+  CapabilityEvidenceInvalidateInput,
+  CapabilityEvidenceQuery,
+  CapabilityEvidenceRecordInput,
+} from "./capabilityEvidence";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
 
@@ -241,6 +246,9 @@ export const WS_METHODS = {
   serverCreateExternalMcpIntegration: "server.createExternalMcpIntegration",
   serverRevokeExternalMcpIntegration: "server.revokeExternalMcpIntegration",
   serverRefreshExternalMcpPairing: "server.refreshExternalMcpPairing",
+  capabilityEvidenceRecord: "capabilityEvidence.record",
+  capabilityEvidenceQuery: "capabilityEvidence.query",
+  capabilityEvidenceInvalidate: "capabilityEvidence.invalidate",
   serverListWorktrees: "server.listWorktrees",
   serverListLocalServers: "server.listLocalServers",
   serverStopLocalServer: "server.stopLocalServer",
@@ -446,6 +454,9 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.serverCreateExternalMcpIntegration, ExternalMcpCreateIntegrationInput),
   tagRequestBody(WS_METHODS.serverRevokeExternalMcpIntegration, ExternalMcpRevokeIntegrationInput),
   tagRequestBody(WS_METHODS.serverRefreshExternalMcpPairing, ExternalMcpRefreshPairingInput),
+  tagRequestBody(WS_METHODS.capabilityEvidenceRecord, CapabilityEvidenceRecordInput),
+  tagRequestBody(WS_METHODS.capabilityEvidenceQuery, CapabilityEvidenceQuery),
+  tagRequestBody(WS_METHODS.capabilityEvidenceInvalidate, CapabilityEvidenceInvalidateInput),
   tagRequestBody(WS_METHODS.serverListWorktrees, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverListLocalServers, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverStopLocalServer, ServerStopLocalServerInput),


### PR DESCRIPTION
## Linked issues

- **KAR-524 — Build local conformance runner and hostile reference agents** → Closes #143
- **Map:** #138 · **PRD:** #139

Part of **Synara — Bring Your Own Agents** (BYO Agents v1) — [PRD](https://linear.app/kartiksworkspace/document/prd-bring-your-own-agents-1b6330f9c430).

## What this is
Implements [KAR-524](https://linear.app/kartiksworkspace/issue/KAR-524/build-local-conformance-runner-and-hostile-reference-agents) — makes external-agent compatibility measurable *before* connection, proving malformed/misbehaving agents fail locally without corrupting Synara state. Stacks on KAR-523's capability evidence model (PR #154).

## Changes
- `apps/server/scripts/acp-hostile-agent.ts` — deterministic hostile ACP fixture with **15 selectable fault modes** (initialize hang, process death mid-turn, malformed frame, stdout pollution, zombie child, partial UTF-8/frame boundary, slow-drip, huge tool output, ignore cancel, flaky cancel, permission-deny loop, late event after close, duplicate/stale IDs, fake resume, capability change mid-session).
- `apps/server/src/conformance/` — `ConformanceRunner` (orchestrates verifier → scratch workspace → bounded probe → append-only observation → re-derived effective state), `AcpConformanceVerifiers` (per-capability ACP bindings with strict framing rejection + agent attribution), `ConformanceScratchWorkspace` (supervised teardown, process-tree cleanup guarantee).
- Wired `CapabilityVerifierRegistry` into `CapabilityEvidenceService` keyed by `(capabilityId, acp-conformance-<harnessVersion>)`; outcomes flow into the append-only evidence `record`.

## Acceptance mapping
- ✓ Valid fixture → repeatable observations (healthy fixture suite)
- ✓ Advertised-but-broken → failed observation + `broken` by policy
- ✓ env/auth → inconclusive (attribution grading)
- ✓ `flaky-cancel` → stable (hysteresis keeps it `degraded`)
- ✓ `stdout-pollution` → fails with agent attribution; strict framing rejection
- ✓ `zombie-child` → no descendant left (supervised teardown proof)
- ✓ No hostile fixture corrupts thread/session persistence (per-run SQLite isolation + exactly-one-observation assertions)

## Verification
- `bun run test`: server 339 files / 3892 pass (0 failures)
- `bun fmt:check` ✓ · `bun lint` ✓ (0 errors) · `bun typecheck` ✓ · `bun migrations:check` ✓

## Status / caveats
- Draft: BYO v1 wave-1. `capability-change` / `stale-ids` / `huge-tool-output` are probed at the `session.start`/`prompt`/`session.resume` surfaces where the ACP protocol offers no mid-session drift signal; those edges are guarded by scratch isolation + persistence assertions rather than a probe assertion.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local conformance runner for external (ACP) agents and persists outcomes in an append-only capability evidence model, enabling us to measure and gate agent compatibility before connection. ACP startup now skips authentication when an agent advertises no auth methods (old: error if no method resolved; new: start succeeds without authenticate; side effect: broader agent support).

- Fulfills KAR-524 (BYO Agents v1) on top of KAR-523’s evidence model.

**Review focus**
- Hostile reference agent: `apps/server/scripts/acp-hostile-agent.ts` with 15 fault modes for deterministic failures.
- Conformance runtime: `apps/server/src/conformance/*` (`ConformanceRunner`, ACP verifiers, scratch workspace, integration tests).
- Capability evidence: repository/service/policy engine and migration under `apps/server/src/capabilityEvidence/*`; new contract types in `packages/contracts/src/capabilityEvidence.ts`; exported via `@synara/contracts`.
- Adapters/runtime: `Cursor`, `Droid`, `Grok` now use `buildAcpGatewayMcpServers`; `AcpSessionRuntime` changes auth negotiation (no-auth agents start without authenticate); added tests.
- API surface: new WS RPCs `capabilityEvidence.record|query|invalidate`; server wiring in `serverLayers.ts` and `wsRpc.ts`.

**Rollout**
- Run DB migration 98 (CapabilityEvidence).
- No adapter config changes required; unified MCP gateway injection is a refactor.
- Expect no behavior change except that agents with no advertised auth now start successfully.

<sup>Written for commit 689836f70b577fdd6fdce7670ec9e39dbba814a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kartikkabadi/synara/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

